### PR TITLE
add prettier-java 1.0.1 binary

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,11 @@
                   <type>zip</type>
                   <classifier>prettier-java-0.8.3</classifier>
                 </artifact>
+                <artifact>
+                  <file>src/main/binaries/prettier-java/1.0.1/prettier-java-1.0.1.zip</file>
+                  <type>zip</type>
+                  <classifier>prettier-java-1.0.1</classifier>
+                </artifact>
               </artifacts>
             </configuration>
           </execution>


### PR DESCRIPTION
Update the prettier-java version to 1.0.1 by adding binaries. The updated binary supports the java 15 text blocks and new switch rules.

@jhaber