### PR TITLE
Fix diff generation

### DIFF
--- a/src/main/java/com/hubspot/maven/plugins/prettier/AbstractPrettierMojo.java
+++ b/src/main/java/com/hubspot/maven/plugins/prettier/AbstractPrettierMojo.java
@@ -72,7 +72,7 @@ public abstract class AbstractPrettierMojo extends PrettierArgs {
           } else if (line.contains("error")) {
             getLog().error(line);
           } else {
-            getLog().warn(line);
+            handlePrettierLogLine(line);
           }
         }
 

--- a/src/main/java/com/hubspot/maven/plugins/prettier/CheckMojo.java
+++ b/src/main/java/com/hubspot/maven/plugins/prettier/CheckMojo.java
@@ -38,6 +38,8 @@ public class CheckMojo extends AbstractPrettierMojo {
   @Override
   protected void handlePrettierLogLine(String line) {
     if (line.endsWith(".java")) {
+      line = trimLogLevel(line);
+
       Path baseDir = project
           .getBasedir()
           .toPath()
@@ -93,6 +95,14 @@ public class CheckMojo extends AbstractPrettierMojo {
       throw new MojoExecutionException("Unable to instantiate diff generator", e);
     } catch (ClassCastException e) {
       throw new MojoExecutionException("Must implement DiffGenerator interface", e);
+    }
+  }
+
+  private static String trimLogLevel(String line) {
+    if (line.contains("]")) {
+      return line.substring(line.indexOf(']') + 2);
+    } else {
+      return line;
     }
   }
 }

--- a/src/main/java/com/hubspot/maven/plugins/prettier/CheckMojo.java
+++ b/src/main/java/com/hubspot/maven/plugins/prettier/CheckMojo.java
@@ -100,6 +100,7 @@ public class CheckMojo extends AbstractPrettierMojo {
 
   private static String trimLogLevel(String line) {
     if (line.contains("]")) {
+      // converts something like '[warn] src/main/java/Test.java' -> 'src/main/java/Test.java'
       return line.substring(line.indexOf(']') + 2);
     } else {
       return line;


### PR DESCRIPTION
Prettier used to print incorrectly formatted files to stdout, but it looks like they now go to stderr which broke our diff generation. This PR updates our handling to also catch lines written to stderr

@kmclarnon @stevegutz @Xcelled 