### PR TITLE
Allow globs without files to still fail check.

### DIFF
--- a/src/main/java/com/hubspot/maven/plugins/prettier/WriteMojo.java
+++ b/src/main/java/com/hubspot/maven/plugins/prettier/WriteMojo.java
@@ -30,4 +30,8 @@ public class WriteMojo extends AbstractPrettierMojo {
       "Error trying to format code with prettier-java: " + status
     );
   }
+
+  @Override
+  protected void handlePrettierFinished() {
+  }
 }


### PR DESCRIPTION
If prettier sees that a glob doesn't find any files it currently will not
fail as the status is 2 but one of the globs didn't find any files.

These changes allow for a final method to be run when
the prettier process completes to fail if files were found to not
pass the code style check even if a glob didn't find any files.
This can happen if you have a sub module that doesn't have any *.html
files but other modules do.

As part of this, the glob suffixes are used to retrieve the list
of files that failed the check to be output.