### PR TITLE
Better handling for multiple globs

### DIFF
--- a/src/main/java/com/hubspot/maven/plugins/prettier/CheckMojo.java
+++ b/src/main/java/com/hubspot/maven/plugins/prettier/CheckMojo.java
@@ -55,8 +55,8 @@ public class CheckMojo extends AbstractPrettierMojo {
   @Override
   protected void handlePrettierNonZeroExit(int status)
     throws MojoFailureException, MojoExecutionException {
-    if (status != 1 || incorrectlyFormattedFiles.isEmpty()) {
-      throw new MojoExecutionException("Error trying to run prettier-java: " + status);
+    if (incorrectlyFormattedFiles.isEmpty()) {
+      return;
     }
 
     if (generateDiff) {
@@ -102,20 +102,5 @@ public class CheckMojo extends AbstractPrettierMojo {
         .toAbsolutePath();
 
     return baseDir.resolve(relativePath);
-  }
-
-  private static String trimLogLevel(String line) {
-    int closeBracketIndex = line.indexOf(']');
-    if (closeBracketIndex < 0) {
-      return line;
-    }
-
-    int startFileIndex = closeBracketIndex + "] ".length();
-    if (startFileIndex >= line.length()) {
-      return line;
-    }
-
-    // converts something like '[warn] src/main/java/Test.java' -> 'src/main/java/Test.java'
-    return line.substring(startFileIndex);
   }
 }

--- a/src/main/java/com/hubspot/maven/plugins/prettier/WriteMojo.java
+++ b/src/main/java/com/hubspot/maven/plugins/prettier/WriteMojo.java
@@ -25,9 +25,5 @@ public class WriteMojo extends AbstractPrettierMojo {
   }
 
   @Override
-  protected void handlePrettierNonZeroExit(int status) throws MojoExecutionException {
-    throw new MojoExecutionException(
-      "Error trying to format code with prettier-java: " + status
-    );
-  }
+  protected void handlePrettierNonZeroExit(int status) {}
 }


### PR DESCRIPTION
Related to #50 

Previously we would ignore status code 2 if it was caused by no matching files. However, since we're passing multiple globs, this isn't a reliably strategy. If any glob doesn't match, we'll get status code 2 and the "no matching files" message will print. However, that doesn't tell us anything about the other globs. They could have incorrectly formatted files, parsing errors, or potentially not even have a parser defined at all.

This PR makes it so that if prettier prints an error log, this will flip a boolean (unless it's a "no files matching" message). If prettier returns a non-0 status code and this boolean is flipped, then we'll fail the Maven plugin execution. 

@magisyn