### PR TITLE
Handle 404 on download

### DIFF
--- a/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/internal/OperatingSystemFamily.java
+++ b/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/internal/OperatingSystemFamily.java
@@ -7,8 +7,8 @@ import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.Set;
-
 import org.apache.maven.plugin.MojoExecutionException;
 
 public enum OperatingSystemFamily {
@@ -49,6 +49,14 @@ public enum OperatingSystemFamily {
       return OperatingSystemFamily.WINDOWS_X64;
     } else {
       throw new MojoExecutionException("Unknown os.name " + osFullName);
+    }
+  }
+
+  public Optional<OperatingSystemFamily> getFallback() {
+    if (this == MAC_ARM) {
+      return Optional.of(MAC_X64);
+    } else {
+      return Optional.empty();
     }
   }
 


### PR DESCRIPTION
Currently we don't check for success on the http response, which means we can get a 404 and happily proceed (and fail later when we try to extract the response body as an archive file). This PR updates the downloader to check response status, and also special-case 404 on mac-arm so that we retry against mac-x64 (older versions of node don't have a mac-arm version)