### PR TITLE
add install prefix option to npm

### DIFF
--- a/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/internal/PrettierDownloader.java
+++ b/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/internal/PrettierDownloader.java
@@ -46,6 +46,8 @@ public class PrettierDownloader {
 
     List<String> command = new ArrayList<>(nodeInstall.getNpmCommand());
     command.add("install");
+    command.add("--prefix");
+    command.add(".");
     command.add("prettier-plugin-java@" + prettierJavaVersion);
 
     log.debug("Running npm install command: " + command);


### PR DESCRIPTION
Not sure if its specific to Linux but npm on my machine is not utilizing the current directory when installing a single dep without a exising package.json file in the directory