### PR TITLE
Add support for disabling generic linebreaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # prettier-maven-plugin
 
-Maven plugin for running [prettier-java](https://github.com/jhipster/prettier-java) during a build. Node, prettier, and prettier-java are bundled into the plugin.
+Maven plugin for running [prettier-java](https://github.com/jhipster/prettier-java) during a build. Node, prettier, and prettier-java are downloaded automatically as needed.
 
 There is a `check` goal which (optionally) fails the build if code isn't formatted correctly, and a `write` goal which rewrites the source code in place. A common setup might be to use the `write` goal during local builds, and the `check` goal during CI builds.
 
@@ -21,7 +21,7 @@ This example will run the `check` goal inside of Travis CI, and the `write` goal
       <artifactId>prettier-maven-plugin</artifactId>
       <version>0.16</version>
       <configuration>
-        <prettierJavaVersion>1.5.0</prettierJavaVersion>
+        <prettierJavaVersion>2.0.0</prettierJavaVersion>
         <printWidth>90</printWidth>
         <tabWidth>2</tabWidth>
         <useTabs>false</useTabs>
@@ -93,6 +93,7 @@ If you want to customize the behavior of prettier, you can use a normal prettier
 | ignoreConfigFile    | prettier.ignoreConfigFile    | `false`                          | If set to true, pretter will be invoked with `--no-config`. More information [here](https://prettier.io/docs/en/cli.html#--no-config)                                                                                                                             |
 | ignoreEditorConfig  | prettier.ignoreEditorConfig  | `false`                          | If set to true, pretter will be invoked with `--no-editorconfig`. More information [here](https://prettier.io/docs/en/cli.html#--no-editorconfig)                                                                                                                 |
 | inputGlobs          | prettier.inputGlobs          | `src/{main,test}/java/**/*.java` | Controls the input paths passed to prettier, useful for formatting additional directories or file types. More information [here](https://prettier.io/docs/en/cli.html#file-patterns)                                                                              |
+| disableGenericsLinebreaks | prettier.disableGenericsLinebreaks | `false` | Prevents prettier from adding linebreaks to generic type declarations (see https://github.com/HubSpot/prettier-maven-plugin/pull/78 for more background) |
 
 ### Note
 

--- a/prettier-maven-plugin-integration-tests/.blazar.yaml
+++ b/prettier-maven-plugin-integration-tests/.blazar.yaml
@@ -1,2 +1,5 @@
 env:
   PRETTIER_NODE_VERSION: 10.17.0
+
+depends:
+  - prettier-maven-plugin

--- a/prettier-maven-plugin-integration-tests/src/test/java/com/hubspot/maven/plugins/prettier/AbstractPrettierMojoTest.java
+++ b/prettier-maven-plugin-integration-tests/src/test/java/com/hubspot/maven/plugins/prettier/AbstractPrettierMojoTest.java
@@ -1,5 +1,8 @@
 package com.hubspot.maven.plugins.prettier;
 
+import com.google.common.collect.ImmutableSet;
+import com.google.common.io.CharStreams;
+import com.google.common.io.Resources;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -17,10 +20,6 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.google.common.collect.ImmutableSet;
-import com.google.common.io.CharStreams;
-import com.google.common.io.Resources;
-
 public abstract class AbstractPrettierMojoTest {
   private static final Logger LOG = Logger.getLogger(AbstractPrettierMojoTest.class.getName());
 
@@ -34,7 +33,7 @@ public abstract class AbstractPrettierMojoTest {
   protected static final String EMPTY = "empty/*.java";
   protected static final String BUILD_SUCCESS = "BUILD SUCCESS";
   protected static final String BUILD_FAILURE = "BUILD FAILURE";
-  private static final Set<String> PRETTIER_JAVA_VERSIONS_TO_TEST = ImmutableSet.of("1.5.0", "1.6.1");
+  private static final Set<String> PRETTIER_JAVA_VERSIONS_TO_TEST = ImmutableSet.of("1.6.2", "2.0.0");
 
   protected static Set<String> getPrettierJavaVersionsToTest() {
     return PRETTIER_JAVA_VERSIONS_TO_TEST;

--- a/prettier-maven-plugin-integration-tests/src/test/java/com/hubspot/maven/plugins/prettier/TestConfiguration.java
+++ b/prettier-maven-plugin-integration-tests/src/test/java/com/hubspot/maven/plugins/prettier/TestConfiguration.java
@@ -1,10 +1,9 @@
 package com.hubspot.maven.plugins.prettier;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class TestConfiguration {
   public enum Goal {
@@ -41,7 +40,7 @@ public class TestConfiguration {
     return template
         .replace(
             "${nodeVersion}",
-            MoreObjects.firstNonNull(System.getenv("PRETTIER_NODE_VERSION"), "16.13.2")
+            MoreObjects.firstNonNull(System.getenv("PRETTIER_NODE_VERSION"), "19.3.0")
         )
         .replace("${pluginVersion}", System.getenv("PLUGIN_VERSION"))
         .replace("${prettierJavaVersion}", prettierJavaVersion)

--- a/prettier-maven-plugin/.blazar.yaml
+++ b/prettier-maven-plugin/.blazar.yaml
@@ -1,0 +1,2 @@
+provides:
+  - prettier-maven-plugin

--- a/prettier-maven-plugin/pom.xml
+++ b/prettier-maven-plugin/pom.xml
@@ -38,6 +38,10 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
       <version>4.9.3</version>

--- a/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/AbstractPrettierMojo.java
+++ b/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/AbstractPrettierMojo.java
@@ -1,5 +1,6 @@
 package com.hubspot.maven.plugins.prettier;
 
+import com.hubspot.maven.plugins.prettier.internal.NodeInstall;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -10,8 +11,6 @@ import java.util.List;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Parameter;
-
-import com.hubspot.maven.plugins.prettier.internal.NodeInstall;
 
 public abstract class AbstractPrettierMojo extends PrettierArgs {
 
@@ -98,7 +97,7 @@ public abstract class AbstractPrettierMojo extends PrettierArgs {
     );
   }
 
-  protected List<String> basePrettierCommand() throws MojoExecutionException {
+  protected List<String> basePrettierCommand() throws MojoExecutionException, MojoFailureException {
     NodeInstall nodeInstall = resolveNodeInstall();
 
     Path prettierJavaDirectory = downloadPrettierJava(nodeInstall);

--- a/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/PrettierArgs.java
+++ b/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/PrettierArgs.java
@@ -1,7 +1,14 @@
 package com.hubspot.maven.plugins.prettier;
 
+import com.google.common.io.Resources;
+import com.hubspot.maven.plugins.prettier.internal.NodeDownloader;
+import com.hubspot.maven.plugins.prettier.internal.NodeInstall;
+import com.hubspot.maven.plugins.prettier.internal.OperatingSystemFamily;
+import com.hubspot.maven.plugins.prettier.internal.PrettierDownloader;
+import com.hubspot.maven.plugins.prettier.internal.PrettierPatcher;
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -9,19 +16,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-
 import javax.annotation.Nullable;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
-
-import com.hubspot.maven.plugins.prettier.internal.NodeDownloader;
-import com.hubspot.maven.plugins.prettier.internal.NodeInstall;
-import com.hubspot.maven.plugins.prettier.internal.OperatingSystemFamily;
-import com.hubspot.maven.plugins.prettier.internal.PrettierDownloader;
 
 public abstract class PrettierArgs extends AbstractMojo {
   /**
@@ -70,6 +72,9 @@ public abstract class PrettierArgs extends AbstractMojo {
   @Parameter(defaultValue = "false", property = "prettier.ignoreEditorConfig")
   protected boolean ignoreEditorConfig;
 
+  @Parameter(defaultValue = "false", property = "prettier.disableGenericsLinebreaks")
+  protected boolean disableGenericsLinebreaks;
+
   @Nullable
   @Parameter(property = "prettier.endOfLine")
   protected String endOfLine;
@@ -109,7 +114,7 @@ public abstract class PrettierArgs extends AbstractMojo {
     }
   }
 
-  protected Path downloadPrettierJava(NodeInstall nodeInstall) throws MojoExecutionException {
+  protected Path downloadPrettierJava(NodeInstall nodeInstall) throws MojoExecutionException, MojoFailureException {
     synchronized (PRETTIER_JAVA_DOWNLOAD_LOCK) {
       Path installDirectory = localRepositoryDirectory();
 
@@ -119,7 +124,22 @@ public abstract class PrettierArgs extends AbstractMojo {
         getLog()
       );
 
-      return prettierDownloader.downloadPrettierJava(prettierJavaVersion);
+      Path prettierJava = prettierDownloader.downloadPrettierJava(prettierJavaVersion);
+
+      if (disableGenericsLinebreaks) {
+        if (prettierJavaVersion.startsWith("2")) {
+          URL patch = Resources.getResource("no-linebreak-generics.patch");
+          return new PrettierPatcher(prettierJava, getLog()).patch(patch);
+        } else if ("1.5.0".compareTo(prettierJavaVersion) > 0) {
+          // versions before 1.5.0 don't linebreak generics
+          return prettierJava;
+        } else {
+          getLog().error("Disabling generic linebreaks is only supported for prettier-java v2");
+          throw new MojoFailureException("Disabling generic linebreaks is only supported for prettier-java v2");
+        }
+      } else {
+        return prettierJava;
+      }
     }
   }
 

--- a/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/PrintArgsMojo.java
+++ b/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/PrintArgsMojo.java
@@ -1,16 +1,16 @@
 package com.hubspot.maven.plugins.prettier;
 
+import com.hubspot.maven.plugins.prettier.internal.NodeInstall;
 import java.nio.file.Path;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
-
-import com.hubspot.maven.plugins.prettier.internal.NodeInstall;
 
 @Mojo(name = "print-args", requiresProject = false)
 public class PrintArgsMojo extends PrettierArgs {
 
   @Override
-  public final void execute() throws MojoExecutionException {
+  public final void execute() throws MojoExecutionException, MojoFailureException {
     NodeInstall nodeInstall = resolveNodeInstall();
 
     Path prettierJavaDirectory = downloadPrettierJava(nodeInstall);

--- a/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/internal/PrettierPatcher.java
+++ b/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/internal/PrettierPatcher.java
@@ -1,0 +1,73 @@
+package com.hubspot.maven.plugins.prettier.internal;
+
+import com.google.common.io.Resources;
+import java.io.File;
+import java.io.IOException;
+import java.lang.ProcessBuilder.Redirect;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+
+public class PrettierPatcher {
+  private final Path originalDirectory;
+  private final Log log;
+
+  public PrettierPatcher(Path originalDirectory, Log log) {
+    this.originalDirectory = originalDirectory;
+    this.log = log;
+  }
+
+  public Path patch(URL patch) throws MojoExecutionException {
+    Path patchDirectory = originalDirectory.resolveSibling(originalDirectory.getFileName() + "-patched");
+
+    if (Files.exists(patchDirectory)) {
+      log.debug("Reusing patched prettier-java at: " + patchDirectory);
+    } else {
+      try {
+        Path tmpDir = FileUtils.copyDirectory(originalDirectory);
+        applyPatch(patch, tmpDir);
+        FileUtils.move(tmpDir, patchDirectory);
+        log.debug("Patched prettier-java to: " + patchDirectory);
+      } catch (IOException e) {
+        throw new MojoExecutionException("Error patching prettier-java", e);
+      }
+    }
+
+    return patchDirectory;
+  }
+
+  private void applyPatch(URL patch, Path directory) throws MojoExecutionException, IOException {
+    List<String> command = Arrays.asList("patch", "-p1", "-f");
+    log.debug("Running patch command: " + command);
+
+    Process process = new ProcessBuilder(command.toArray(new String[0]))
+        .directory(directory.toFile())
+        .redirectInput(copyToFile(patch))
+        .redirectOutput(Redirect.INHERIT)
+        .redirectError(Redirect.INHERIT)
+        .start();
+
+    try {
+      int exitCode = process.waitFor();
+      if (exitCode != 0) {
+        throw new MojoExecutionException("Error patching prettier-java, exit code: " + exitCode);
+      }
+    } catch (InterruptedException e) {
+      throw new MojoExecutionException("Interrupted while patching prettier-java", e);
+    }
+  }
+
+  private File copyToFile(URL source) throws IOException {
+    Path tmpFile = Files.createTempFile(originalDirectory.getParent(), "prettier-", ".patch");
+    tmpFile.toFile().deleteOnExit();
+
+    byte[] bytes = Resources.toByteArray(source);
+    Files.write(tmpFile, bytes);
+
+    return tmpFile.toFile();
+  }
+}

--- a/prettier-maven-plugin/src/main/resources/no-linebreak-generics.patch
+++ b/prettier-maven-plugin/src/main/resources/no-linebreak-generics.patch
@@ -1,0 +1,40 @@
+diff --git a/node_modules/prettier-plugin-java/dist/printers/classes.js b/node_modules/prettier-plugin-java/dist/printers/classes.js
+index 25c5fba..d077303 100644
+--- a/node_modules/prettier-plugin-java/dist/printers/classes.js
++++ b/node_modules/prettier-plugin-java/dist/printers/classes.js
+@@ -104,12 +104,12 @@ var ClassesPrettierVisitor = /** @class */ (function (_super) {
+     };
+     ClassesPrettierVisitor.prototype.typeParameters = function (ctx) {
+         var typeParameterList = this.visit(ctx.typeParameterList);
+-        return (0, printer_utils_1.putIntoBraces)(typeParameterList, softline, ctx.Less[0], ctx.Greater[0]);
++        return (0, printer_utils_1.rejectAndConcat)([ctx.Less[0], typeParameterList, ctx.Greater[0]]);
+     };
+     ClassesPrettierVisitor.prototype.typeParameterList = function (ctx) {
+         var typeParameter = this.mapVisit(ctx.typeParameter);
+-        var commas = ctx.Comma ? ctx.Comma.map(function (elt) { return (0, prettier_builder_1.concat)([elt, line]); }) : [];
+-        return (0, prettier_builder_1.group)((0, printer_utils_1.rejectAndJoinSeps)(commas, typeParameter));
++        var commas = ctx.Comma ? ctx.Comma.map(function (elt) { return (0, prettier_builder_1.concat)([elt, " "]); }) : [];
++        return (0, printer_utils_1.rejectAndJoinSeps)(commas, typeParameter);
+     };
+     ClassesPrettierVisitor.prototype.superclass = function (ctx) {
+         return (0, prettier_builder_1.join)(" ", [ctx.Extends[0], this.visit(ctx.classType)]);
+diff --git a/node_modules/prettier-plugin-java/dist/src/printers/classes.js b/node_modules/prettier-plugin-java/dist/src/printers/classes.js
+index b80d09f..120e2b5 100644
+--- a/node_modules/prettier-plugin-java/dist/src/printers/classes.js
++++ b/node_modules/prettier-plugin-java/dist/src/printers/classes.js
+@@ -104,12 +104,12 @@ var ClassesPrettierVisitor = /** @class */ (function (_super) {
+     };
+     ClassesPrettierVisitor.prototype.typeParameters = function (ctx) {
+         var typeParameterList = this.visit(ctx.typeParameterList);
+-        return printer_utils_1.putIntoBraces(typeParameterList, softline, ctx.Less[0], ctx.Greater[0]);
++        return printer_utils_1.rejectAndConcat([ctx.Less[0], typeParameterList, ctx.Greater[0]]);
+     };
+     ClassesPrettierVisitor.prototype.typeParameterList = function (ctx) {
+         var typeParameter = this.mapVisit(ctx.typeParameter);
+-        var commas = ctx.Comma ? ctx.Comma.map(function (elt) { return prettier_builder_1.concat([elt, line]); }) : [];
+-        return prettier_builder_1.group(printer_utils_1.rejectAndJoinSeps(commas, typeParameter));
++        var commas = ctx.Comma ? ctx.Comma.map(function (elt) { return prettier_builder_1.concat([elt, " "]); }) : [];
++        return printer_utils_1.rejectAndJoinSeps(commas, typeParameter);
+     };
+     ClassesPrettierVisitor.prototype.superclass = function (ctx) {
+         return prettier_builder_1.join(" ", [ctx.Extends[0], this.visit(ctx.classType)]);


### PR DESCRIPTION
Related to: https://github.com/jhipster/prettier-java/issues/526

That issue has stagnated a bit, so this PR attempts to work around the issue in the maven plugin. I created a patch file that reverts https://github.com/jhipster/prettier-java/pull/512 and bundled it into the maven plugin. Based on a configurable option, we will apply this patch to prettier-java after downloading. This effectively makes the generic line-breaking behavior configurable so that we can disable it 