### PR TITLE
Add logging for unrecognized loglines

### DIFF
--- a/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/CheckMojo.java
+++ b/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/CheckMojo.java
@@ -49,6 +49,10 @@ public class CheckMojo extends AbstractPrettierMojo {
       } else {
         getLog().warn(message);
       }
+    } else {
+       if (getLog().isDebugEnabled()) {
+        getLog().debug("Prettier output >" + line);
+      }
     }
   }
 


### PR DESCRIPTION
Add debug logging if logline is not recognized as a file, so that other potential errors can be revealed.

cc @stevegutz @jhaber @Xcelled 