### PR TITLE
fix for https://github.com/HubSpot/prettier-maven-plugin/issues/79

### DIFF
--- a/prettier-maven-plugin/pom.xml
+++ b/prettier-maven-plugin/pom.xml
@@ -38,6 +38,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
+      <version>3.9.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/AbstractPrettierMojo.java
+++ b/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/AbstractPrettierMojo.java
@@ -8,11 +8,14 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Parameter;
 
 public abstract class AbstractPrettierMojo extends PrettierArgs {
+
+  private static final DefaultArtifactVersion OLD_VERSION = new DefaultArtifactVersion("0.8.1");
 
   @Parameter(defaultValue = "false")
   private boolean skip;
@@ -50,32 +53,25 @@ public abstract class AbstractPrettierMojo extends PrettierArgs {
         .directory(project.getBasedir())
         .start();
       try (
-        InputStreamReader stdoutReader = new InputStreamReader(
-          process.getInputStream(),
-          StandardCharsets.UTF_8
-        );
-        BufferedReader stdout = new BufferedReader(stdoutReader);
-        InputStreamReader stderrReader = new InputStreamReader(
-          process.getErrorStream(),
+          InputStreamReader stdoutReader = new InputStreamReader(
+              process.getInputStream(),
+            StandardCharsets.UTF_8
+          );
+          BufferedReader stdout = new BufferedReader(stdoutReader);
+          InputStreamReader stderrReader = new InputStreamReader(
+            process.getErrorStream(),
           StandardCharsets.UTF_8
         );
         BufferedReader stderr = new BufferedReader(stderrReader)
       ) {
-        String line;
-        while ((line = stdout.readLine()) != null) {
-          handlePrettierLogLine(line);
-        }
-
         boolean hasError = false;
-        while ((line = stderr.readLine()) != null) {
-          if (line.contains("No matching files.") || line.contains("No files matching")) {
-            getLog().info(trimLogLevel(line));
-          } else if (line.contains("error")) {
-            getLog().error(trimLogLevel(line));
-            hasError = true;
-          } else {
-            handlePrettierLogLine(line);
-          }
+        if( new DefaultArtifactVersion(prettierJavaVersion).compareTo(OLD_VERSION) > 0){
+          hasError = readFromStdErr(stderr);
+          readFromStdOut(stdout);
+        }
+        else{
+          readFromStdOut(stdout);
+          hasError = readFromStdErr(stderr);
         }
 
         int status = process.waitFor();
@@ -89,6 +85,29 @@ public abstract class AbstractPrettierMojo extends PrettierArgs {
     } catch (IOException | InterruptedException e) {
       throw new MojoExecutionException("Error trying to run prettier-java", e);
     }
+  }
+
+  private boolean readFromStdErr(BufferedReader stderr) throws IOException {
+    String line;
+    boolean hasError = false;
+    while ((line = stderr.readLine()) != null) {
+      if (line.contains("No matching files.") || line.contains("No files matching")) {
+        getLog().info(trimLogLevel(line));
+      } else if (line.contains("error")) {
+        getLog().error(trimLogLevel(line));
+        hasError = true;
+      } else {
+        handlePrettierLogLine(line);
+      }
+    }
+    return hasError;
+  }
+
+  private void readFromStdOut(BufferedReader stdout) throws IOException {
+    String line;
+    while ((line = stdout.readLine()) != null) {
+    handlePrettierLogLine(line);
+   }
   }
 
   protected static MojoExecutionException prettierExecutionFailed(int status) throws MojoExecutionException {

--- a/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/PrettierArgs.java
+++ b/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/PrettierArgs.java
@@ -48,7 +48,7 @@ public abstract class PrettierArgs extends AbstractMojo {
   private String npmPath;
 
   @Parameter(defaultValue = "0.7.0", property = "prettier.prettierJavaVersion")
-  private String prettierJavaVersion;
+  protected String prettierJavaVersion;
 
   // TODO remove
   @Parameter(defaultValue = "false")


### PR DESCRIPTION
fix for https://github.com/HubSpot/prettier-maven-plugin/issues/79

It looks like java-prettier before version 0.8.2 initialize the stdout/stderr in a different order than from version greater than 0.8.2.

I added a check and read from stdout and then stderr if we have a version set prior to 0.8.2 and the other way arround if we set a version from 0.8.2 on.