### PR TITLE
Check for corrupted installs

### DIFF
--- a/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/internal/FileUtils.java
+++ b/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/internal/FileUtils.java
@@ -83,7 +83,7 @@ public class FileUtils {
     }
   }
 
-  private static void deleteDirectory(Path directory) throws MojoExecutionException {
+  public static void deleteDirectory(Path directory) throws MojoExecutionException {
     try {
       Files.walkFileTree(
           directory,

--- a/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/internal/PrettierDownloader.java
+++ b/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/internal/PrettierDownloader.java
@@ -9,6 +9,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 
 public class PrettierDownloader {
+  private static final String PRETTIER_BIN_PATH = "node_modules/prettier/bin-prettier.js";
   private final Path installDirectory;
   private final NodeInstall nodeInstall;
   private final Log log;
@@ -21,7 +22,7 @@ public class PrettierDownloader {
 
   public Path downloadPrettierJava(String prettierJavaVersion) throws MojoExecutionException {
     Path prettierDirectory = installDirectory.resolve("prettier-java-" + prettierJavaVersion);
-    Path prettierBin = prettierDirectory.resolve("node_modules/prettier/bin-prettier.js");
+    Path prettierBin = prettierDirectory.resolve(PRETTIER_BIN_PATH);
 
     if (Files.exists(prettierDirectory) && Files.exists(prettierBin)) {
       log.debug("Reusing cached prettier-java at: " + prettierDirectory);
@@ -63,8 +64,12 @@ public class PrettierDownloader {
 
     try {
       int exitCode = process.waitFor();
+      boolean prettierBinExists = Files.exists(tmpDir.resolve(PRETTIER_BIN_PATH));
       if (exitCode != 0) {
         throw new MojoExecutionException("Error downloading prettier-java, exit code: " + exitCode);
+      }
+      if (!prettierBinExists) {
+        throw new MojoExecutionException("Error downloading prettier-java, prettier bin was not found");
       }
     } catch (InterruptedException e) {
       throw new MojoExecutionException("Interrupted while downloading prettier-java", e);

--- a/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/internal/PrettierDownloader.java
+++ b/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/internal/PrettierDownloader.java
@@ -5,7 +5,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 
@@ -22,20 +21,25 @@ public class PrettierDownloader {
 
   public Path downloadPrettierJava(String prettierJavaVersion) throws MojoExecutionException {
     Path prettierDirectory = installDirectory.resolve("prettier-java-" + prettierJavaVersion);
+    Path prettierBin = prettierDirectory.resolve("node_modules/prettier/bin-prettier.js");
 
-    if (Files.exists(prettierDirectory)) {
+    if (Files.exists(prettierDirectory) && Files.exists(prettierBin)) {
       log.debug("Reusing cached prettier-java at: " + prettierDirectory);
-    } else {
-      try {
-        Path tmpDir = installPrettierJavaToTmpDir(prettierJavaVersion);
-        FileUtils.move(tmpDir, prettierDirectory);
-        log.debug("Downloaded prettier-java to: " + prettierDirectory);
-      } catch (IOException e) {
-        throw new MojoExecutionException("Error downloading prettier-java", e);
-      }
+      return prettierDirectory;
+    } else if (Files.exists(prettierDirectory) && !Files.exists(prettierBin)) {
+      log.warn("Corrupted prettier install, going to delete and re-download");
+      FileUtils.deleteDirectory(prettierDirectory);
     }
 
-    return prettierDirectory;
+    try {
+      Path tmpDir = installPrettierJavaToTmpDir(prettierJavaVersion);
+      FileUtils.move(tmpDir, prettierDirectory);
+
+      log.info("Downloaded prettier-java to: " + prettierDirectory);
+      return prettierDirectory;
+    } catch (IOException e) {
+      throw new MojoExecutionException("Error downloading prettier-java", e);
+    }
   }
 
   private Path installPrettierJavaToTmpDir(String prettierJavaVersion) throws MojoExecutionException, IOException {


### PR DESCRIPTION
Two places that could have a corrupted install in prettier-java is during the actual download/npm install and a bad cache.

This add a check for the `node_modules/prettier/bin-prettier.js` file during the install and validated it when reusing the cache