### PR TITLE
Alias basepom.install.skip to maven.install.skip

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,8 @@
   <properties>
     <basepom.check.skip-license>true</basepom.check.skip-license>
     <basepom.check.skip-spotbugs>true</basepom.check.skip-spotbugs>
+    <basepom.install.skip>${maven.install.skip}</basepom.install.skip>
+    <maven.install.skip>false</maven.install.skip>
 
     <!-- version 3.0.0-M1 doesn't seem to work with our GCS wagon -->
     <dep.plugin.deploy.version>2.8.2</dep.plugin.deploy.version>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
   <properties>
     <basepom.check.skip-license>true</basepom.check.skip-license>
     <basepom.check.skip-spotbugs>true</basepom.check.skip-spotbugs>
+    <basepom.deploy.skip>false</basepom.deploy.skip>
     <basepom.install.skip>${maven.install.skip}</basepom.install.skip>
     <maven.install.skip>false</maven.install.skip>
 


### PR DESCRIPTION
Seems like [basepom 49](https://github.com/basepom/basepom/releases/tag/basepom-49) added `basepom.install.skip` property, which takes precedence over `maven.install.skip` commandline arg (so calling maven with `-Dmaven.install.skip` has no effect). This PR is a quick hack to make `-Dmaven.install.skip` work as it did previously

@stevie400 @Xcelled @suruuK @kmclarnon @jaredstehler 