### PR TITLE
use provided nodePath for npm if npmPath is npm-cli.js

### DIFF
--- a/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/PrettierArgs.java
+++ b/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/PrettierArgs.java
@@ -100,7 +100,11 @@ public abstract class PrettierArgs extends AbstractMojo {
     }
 
     if (maybeNode.isPresent() && maybeNpm.isPresent()) {
-      return new NodeInstall(maybeNode.get(), Arrays.asList(maybeNpm.get()));
+      if (maybeNpm.get().endsWith("npm-cli.js")) {
+        return new NodeInstall(maybeNode.get(), Arrays.asList(maybeNode.get(), maybeNpm.get()));
+      } else {
+        return new NodeInstall(maybeNode.get(), Arrays.asList(maybeNpm.get()));
+      }
     } else {
       NodeInstall nodeInstall = downloadNode();
 


### PR DESCRIPTION
currently, if you specify a provided `nodePath` and `npmPath`, the prettier downloader invokes `npmPath` directly, which requires `node` on the `PATH`.

updates the npm command to use the provided `nodePath`, if the provided `npmPath` references an `npm-cli.js`. this matches the logic which uses the downloaded node runtime for npm: https://github.com/HubSpot/prettier-maven-plugin/blob/7104b57ae1d17cbf46fe114dfbef12ca8a3cd88e/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/internal/OperatingSystemFamily.java#L88-L91

@stevie400 @Xcelled @suruuK @kmclarnon 
