### PR TITLE
allow specifying custom download url for node runtime

### DIFF
--- a/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/PrettierArgs.java
+++ b/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/PrettierArgs.java
@@ -1,11 +1,5 @@
 package com.hubspot.maven.plugins.prettier;
 
-import com.google.common.io.Resources;
-import com.hubspot.maven.plugins.prettier.internal.NodeDownloader;
-import com.hubspot.maven.plugins.prettier.internal.NodeInstall;
-import com.hubspot.maven.plugins.prettier.internal.OperatingSystemFamily;
-import com.hubspot.maven.plugins.prettier.internal.PrettierDownloader;
-import com.hubspot.maven.plugins.prettier.internal.PrettierPatcher;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -16,7 +10,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+
 import javax.annotation.Nullable;
+
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -24,6 +20,13 @@ import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+
+import com.google.common.io.Resources;
+import com.hubspot.maven.plugins.prettier.internal.NodeDownloader;
+import com.hubspot.maven.plugins.prettier.internal.NodeInstall;
+import com.hubspot.maven.plugins.prettier.internal.OperatingSystemFamily;
+import com.hubspot.maven.plugins.prettier.internal.PrettierDownloader;
+import com.hubspot.maven.plugins.prettier.internal.PrettierPatcher;
 
 public abstract class PrettierArgs extends AbstractMojo {
   /**
@@ -40,6 +43,9 @@ public abstract class PrettierArgs extends AbstractMojo {
 
   @Parameter(defaultValue = "16.13.2", property = "prettier.nodeVersion")
   private String nodeVersion;
+
+  @Parameter(defaultValue = "", property = "prettier.nodeDownloadUrl")
+  private String nodeDownloadUrl;
 
   @Parameter(defaultValue = "", property = "prettier.nodePath")
   private String nodePath;
@@ -123,9 +129,9 @@ public abstract class PrettierArgs extends AbstractMojo {
       Path installDirectory = localRepositoryDirectory();
 
       PrettierDownloader prettierDownloader = new PrettierDownloader(
-        installDirectory,
-        nodeInstall,
-        getLog()
+          installDirectory,
+          nodeInstall,
+          getLog()
       );
 
       Path prettierJava = prettierDownloader.downloadPrettierJava(prettierJavaVersion);
@@ -151,8 +157,13 @@ public abstract class PrettierArgs extends AbstractMojo {
     synchronized (NODE_DOWNLOAD_LOCK) {
       Path installDirectory = localRepositoryDirectory();
 
+      Optional<String> maybeNodeDownloadUrl = Optional.empty();
+      if (nodeDownloadUrl != null && !nodeDownloadUrl.isEmpty()) {
+        maybeNodeDownloadUrl = Optional.of(nodeDownloadUrl);
+      }
+
       try {
-        NodeDownloader nodeDownloader = new NodeDownloader(installDirectory, getLog());
+        NodeDownloader nodeDownloader = new NodeDownloader(maybeNodeDownloadUrl, installDirectory, getLog());
         return nodeDownloader.download(nodeVersion);
       } catch (IOException e) {
         throw new MojoExecutionException("Error downloading node", e);

--- a/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/internal/NodeDownloader.java
+++ b/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/internal/NodeDownloader.java
@@ -7,20 +7,24 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Optional;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.logging.Log;
 
 public class NodeDownloader {
   private static final OkHttpClient HTTP_CLIENT = new OkHttpClient();
 
+  private final Optional<String> customDownloadUrl;
   private final Path installDirectory;
   private final Log log;
 
-  public NodeDownloader(Path installDirectory, Log log) {
+  public NodeDownloader(Optional<String> customDownloadUrl, Path installDirectory, Log log) {
+    this.customDownloadUrl = customDownloadUrl;
     this.installDirectory = installDirectory;
     this.log = log;
   }
@@ -36,7 +40,7 @@ public class NodeDownloader {
     if (Files.exists(targetDirectory)) {
       log.debug("Reusing cached node at: " + targetDirectory);
     } else {
-      String downloadUrl = os.getNodeDownloadUrl(version);
+      String downloadUrl = customDownloadUrl.orElseGet(() -> os.getNodeDownloadUrl(version));
       log.debug("Downloading node from url: " + downloadUrl);
 
       Optional<Path> maybeNodeArchive = downloadToTmpFile(downloadUrl);


### PR DESCRIPTION
allow completely overriding nodejs download url, for certain cases such as air-gapped environments.

fixes https://github.com/HubSpot/prettier-maven-plugin/issues/72

@jhaber 
