### PR TITLE
Add support for prettier-java v2.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,19 +115,4 @@
       </plugins>
     </pluginManagement>
   </build>
-
-  <profiles>
-    <profile>
-      <id>travis</id>
-      <activation>
-        <property>
-          <name>env.TRAVIS</name>
-        </property>
-      </activation>
-      <properties>
-        <basepom.test.reuse-vm>false</basepom.test.reuse-vm>
-        <basepom.test.fork-count>1</basepom.test.fork-count>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -87,9 +87,9 @@
         <version>2.11.4</version>
       </dependency>
       <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.13.2</version>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <version>5.9.3</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>

--- a/prettier-maven-plugin-integration-tests/pom.xml
+++ b/prettier-maven-plugin-integration-tests/pom.xml
@@ -11,7 +11,7 @@
   <artifactId>prettier-maven-plugin-integration-tests</artifactId>
 
   <properties>
-    <basepom.test.timeout>360</basepom.test.timeout>
+    <basepom.test.timeout>960</basepom.test.timeout>
   </properties>
 
   <dependencies>

--- a/prettier-maven-plugin-integration-tests/pom.xml
+++ b/prettier-maven-plugin-integration-tests/pom.xml
@@ -11,7 +11,7 @@
   <artifactId>prettier-maven-plugin-integration-tests</artifactId>
 
   <properties>
-    <basepom.test.timeout>240</basepom.test.timeout>
+    <basepom.test.timeout>360</basepom.test.timeout>
   </properties>
 
   <dependencies>

--- a/prettier-maven-plugin-integration-tests/pom.xml
+++ b/prettier-maven-plugin-integration-tests/pom.xml
@@ -21,8 +21,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/prettier-maven-plugin-integration-tests/src/test/java/com/hubspot/maven/plugins/prettier/AbstractPrettierMojoTest.java
+++ b/prettier-maven-plugin-integration-tests/src/test/java/com/hubspot/maven/plugins/prettier/AbstractPrettierMojoTest.java
@@ -76,10 +76,6 @@ public abstract class AbstractPrettierMojoTest {
     }
   }
 
-  protected static boolean isNewishVersion(String prettierJavaVersion) {
-    return prettierJavaVersion.startsWith("1.");
-  }
-
   protected static String reformattedFile(String pattern) {
     return "Reformatted file: " + pattern.substring(0, pattern.indexOf('/'));
   }

--- a/prettier-maven-plugin-integration-tests/src/test/java/com/hubspot/maven/plugins/prettier/AbstractPrettierMojoTest.java
+++ b/prettier-maven-plugin-integration-tests/src/test/java/com/hubspot/maven/plugins/prettier/AbstractPrettierMojoTest.java
@@ -33,7 +33,7 @@ public abstract class AbstractPrettierMojoTest {
   protected static final String EMPTY = "empty/*.java";
   protected static final String BUILD_SUCCESS = "BUILD SUCCESS";
   protected static final String BUILD_FAILURE = "BUILD FAILURE";
-  private static final Set<String> PRETTIER_JAVA_VERSIONS_TO_TEST = ImmutableSet.of("1.6.2", "2.0.0");
+  private static final Set<String> PRETTIER_JAVA_VERSIONS_TO_TEST = ImmutableSet.of("1.6.2", "2.0.0", "2.2.0");
 
   protected static Set<String> getPrettierJavaVersionsToTest() {
     return PRETTIER_JAVA_VERSIONS_TO_TEST;

--- a/prettier-maven-plugin-integration-tests/src/test/java/com/hubspot/maven/plugins/prettier/CheckMojoTest.java
+++ b/prettier-maven-plugin-integration-tests/src/test/java/com/hubspot/maven/plugins/prettier/CheckMojoTest.java
@@ -4,266 +4,296 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hubspot.maven.plugins.prettier.TestConfiguration.Goal;
 import java.util.Arrays;
-import org.junit.Test;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
 
 public class CheckMojoTest extends AbstractPrettierMojoTest {
 
-  @Test
-  public void itChecksGoodJava() throws Exception {
-    for (String prettierJavaVersion : getPrettierJavaVersionsToTest()) {
-      TestConfiguration testConfiguration = TestConfiguration
-          .newBuilder()
-          .setPrettierJavaVersion(prettierJavaVersion)
-          .setInputGlobs(Arrays.asList(JAVA_GOOD_FORMATTING))
-          .setGoal(Goal.CHECK)
-          .build();
+  @TestFactory
+  public Stream<DynamicTest> itChecksGoodJava() {
+    return getPrettierJavaVersionsToTest().stream().map(prettierJavaVersion ->
+        DynamicTest.dynamicTest("itChecksGoodJava_prettier-java@" + prettierJavaVersion, () -> {
+          TestConfiguration testConfiguration = TestConfiguration
+              .newBuilder()
+              .setPrettierJavaVersion(prettierJavaVersion)
+              .setInputGlobs(Arrays.asList(JAVA_GOOD_FORMATTING))
+              .setGoal(Goal.CHECK)
+              .build();
 
-      MavenResult result = runMaven(testConfiguration);
+          MavenResult result = runMaven(testConfiguration);
 
-      assertThat(result.getSuccess()).isTrue();
-      assertThat(result.getOutput()).contains(BUILD_SUCCESS);
-      assertThat(result.getOutput()).doesNotContain(noMatchingFiles(JAVA_GOOD_FORMATTING));
-    }
+          assertThat(result.getSuccess()).isTrue();
+          assertThat(result.getOutput()).contains(BUILD_SUCCESS);
+          assertThat(result.getOutput()).doesNotContain(noMatchingFiles(JAVA_GOOD_FORMATTING));
+        })
+    );
   }
 
-  @Test
-  public void itChecksGoodJs() throws Exception {
-    for (String prettierJavaVersion : getPrettierJavaVersionsToTest()) {
-      TestConfiguration testConfiguration = TestConfiguration
-          .newBuilder()
-          .setPrettierJavaVersion(prettierJavaVersion)
-          .setInputGlobs(Arrays.asList(JS_GOOD_FORMATTING))
-          .setGoal(Goal.CHECK)
-          .build();
+  @TestFactory
+  public Stream<DynamicTest> itChecksGoodJs() {
+    return getPrettierJavaVersionsToTest().stream().map(prettierJavaVersion ->
+        DynamicTest.dynamicTest("itChecksGoodJs_prettier-java@" + prettierJavaVersion, () -> {
+          TestConfiguration testConfiguration = TestConfiguration
+              .newBuilder()
+              .setPrettierJavaVersion(prettierJavaVersion)
+              .setInputGlobs(Arrays.asList(JS_GOOD_FORMATTING))
+              .setGoal(Goal.CHECK)
+              .build();
 
-      MavenResult result = runMaven(testConfiguration);
+          MavenResult result = runMaven(testConfiguration);
 
-      assertThat(result.getSuccess()).isTrue();
-      assertThat(result.getOutput()).contains(BUILD_SUCCESS);
-      assertThat(result.getOutput()).doesNotContain(noMatchingFiles(JS_GOOD_FORMATTING));
-    }
+          assertThat(result.getSuccess()).isTrue();
+          assertThat(result.getOutput()).contains(BUILD_SUCCESS);
+          assertThat(result.getOutput()).doesNotContain(noMatchingFiles(JS_GOOD_FORMATTING));
+        })
+    );
   }
 
-  @Test
-  public void itChecksGoodJavaAndGoodJs() throws Exception {
-    for (String prettierJavaVersion : getPrettierJavaVersionsToTest()) {
-      TestConfiguration testConfiguration = TestConfiguration
-          .newBuilder()
-          .setPrettierJavaVersion(prettierJavaVersion)
-          .setInputGlobs(Arrays.asList(JAVA_GOOD_FORMATTING, JS_GOOD_FORMATTING))
-          .setGoal(Goal.CHECK)
-          .build();
+  @TestFactory
+  public Stream<DynamicTest> itChecksGoodJavaAndGoodJs() {
+    return getPrettierJavaVersionsToTest().stream().map(prettierJavaVersion ->
+        DynamicTest.dynamicTest("itChecksGoodJavaAndGoodJs_prettier-java@" + prettierJavaVersion, () -> {
+          TestConfiguration testConfiguration = TestConfiguration
+              .newBuilder()
+              .setPrettierJavaVersion(prettierJavaVersion)
+              .setInputGlobs(Arrays.asList(JAVA_GOOD_FORMATTING, JS_GOOD_FORMATTING))
+              .setGoal(Goal.CHECK)
+              .build();
 
-      MavenResult result = runMaven(testConfiguration);
+          MavenResult result = runMaven(testConfiguration);
 
-      assertThat(result.getSuccess()).isTrue();
-      assertThat(result.getOutput()).contains(BUILD_SUCCESS);
-      assertThat(result.getOutput()).doesNotContain(noMatchingFiles(JAVA_GOOD_FORMATTING));
-      assertThat(result.getOutput()).doesNotContain(noMatchingFiles(JS_GOOD_FORMATTING));
-    }
+          assertThat(result.getSuccess()).isTrue();
+          assertThat(result.getOutput()).contains(BUILD_SUCCESS);
+          assertThat(result.getOutput()).doesNotContain(noMatchingFiles(JAVA_GOOD_FORMATTING));
+          assertThat(result.getOutput()).doesNotContain(noMatchingFiles(JS_GOOD_FORMATTING));
+        })
+    );
   }
 
-  @Test
-  public void itChecksBadJava() throws Exception {
-    for (String prettierJavaVersion : getPrettierJavaVersionsToTest()) {
-      TestConfiguration testConfiguration = TestConfiguration
-          .newBuilder()
-          .setPrettierJavaVersion(prettierJavaVersion)
-          .setInputGlobs(Arrays.asList(JAVA_BAD_FORMATTING))
-          .setGoal(Goal.CHECK)
-          .build();
+  @TestFactory
+  public Stream<DynamicTest> itChecksBadJava() {
+    return getPrettierJavaVersionsToTest().stream().map(prettierJavaVersion ->
+        DynamicTest.dynamicTest("itChecksBadJava_prettier-java@" + prettierJavaVersion, () -> {
+          TestConfiguration testConfiguration = TestConfiguration
+              .newBuilder()
+              .setPrettierJavaVersion(prettierJavaVersion)
+              .setInputGlobs(Arrays.asList(JAVA_BAD_FORMATTING))
+              .setGoal(Goal.CHECK)
+              .build();
 
-      MavenResult result = runMaven(testConfiguration);
+          MavenResult result = runMaven(testConfiguration);
 
-      assertThat(result.getSuccess()).isFalse();
-      assertThat(result.getOutput()).contains(BUILD_FAILURE);
-      assertThat(result.getOutput()).contains(incorrectlyFormattedFile(JAVA_BAD_FORMATTING));
-    }
+          assertThat(result.getSuccess()).isFalse();
+          assertThat(result.getOutput()).contains(BUILD_FAILURE);
+          assertThat(result.getOutput()).contains(incorrectlyFormattedFile(JAVA_BAD_FORMATTING));
+        })
+    );
   }
 
-  @Test
-  public void itChecksBadJs() throws Exception {
-    for (String prettierJavaVersion : getPrettierJavaVersionsToTest()) {
-      TestConfiguration testConfiguration = TestConfiguration
-          .newBuilder()
-          .setPrettierJavaVersion(prettierJavaVersion)
-          .setInputGlobs(Arrays.asList(JS_BAD_FORMATTING))
-          .setGoal(Goal.CHECK)
-          .build();
+  @TestFactory
+  public Stream<DynamicTest> itChecksBadJs() {
+    return getPrettierJavaVersionsToTest().stream().map(prettierJavaVersion ->
+        DynamicTest.dynamicTest("itChecksBadJs_prettier-java@" + prettierJavaVersion, () -> {
+          TestConfiguration testConfiguration = TestConfiguration
+              .newBuilder()
+              .setPrettierJavaVersion(prettierJavaVersion)
+              .setInputGlobs(Arrays.asList(JS_BAD_FORMATTING))
+              .setGoal(Goal.CHECK)
+              .build();
 
-      MavenResult result = runMaven(testConfiguration);
+          MavenResult result = runMaven(testConfiguration);
 
-      assertThat(result.getSuccess()).isFalse();
-      assertThat(result.getOutput()).contains(BUILD_FAILURE);
-      assertThat(result.getOutput()).contains(incorrectlyFormattedFile(JS_BAD_FORMATTING));
-    }
+          assertThat(result.getSuccess()).isFalse();
+          assertThat(result.getOutput()).contains(BUILD_FAILURE);
+          assertThat(result.getOutput()).contains(incorrectlyFormattedFile(JS_BAD_FORMATTING));
+        })
+    );
   }
 
-  @Test
-  public void itChecksBadJavaAndBadJs() throws Exception {
-    for (String prettierJavaVersion : getPrettierJavaVersionsToTest()) {
-      TestConfiguration testConfiguration = TestConfiguration
-          .newBuilder()
-          .setPrettierJavaVersion(prettierJavaVersion)
-          .setInputGlobs(Arrays.asList(JAVA_BAD_FORMATTING, JS_BAD_FORMATTING))
-          .setGoal(Goal.CHECK)
-          .build();
+  @TestFactory
+  public Stream<DynamicTest> itChecksBadJavaAndBadJs() {
+    return getPrettierJavaVersionsToTest().stream().map(prettierJavaVersion ->
+        DynamicTest.dynamicTest("itChecksBadJavaAndBadJs_prettier-java@" + prettierJavaVersion, () -> {
+          TestConfiguration testConfiguration = TestConfiguration
+              .newBuilder()
+              .setPrettierJavaVersion(prettierJavaVersion)
+              .setInputGlobs(Arrays.asList(JAVA_BAD_FORMATTING, JS_BAD_FORMATTING))
+              .setGoal(Goal.CHECK)
+              .build();
 
-      MavenResult result = runMaven(testConfiguration);
+          MavenResult result = runMaven(testConfiguration);
 
-      assertThat(result.getSuccess()).isFalse();
-      assertThat(result.getOutput()).contains(BUILD_FAILURE);
-      assertThat(result.getOutput()).contains(incorrectlyFormattedFile(JAVA_BAD_FORMATTING));
-      assertThat(result.getOutput()).contains(incorrectlyFormattedFile(JS_BAD_FORMATTING));
-    }
+          assertThat(result.getSuccess()).isFalse();
+          assertThat(result.getOutput()).contains(BUILD_FAILURE);
+          assertThat(result.getOutput()).contains(incorrectlyFormattedFile(JAVA_BAD_FORMATTING));
+          assertThat(result.getOutput()).contains(incorrectlyFormattedFile(JS_BAD_FORMATTING));
+        })
+    );
   }
 
-  @Test
-  public void itChecksInvalidJava() throws Exception {
-    for (String prettierJavaVersion : getPrettierJavaVersionsToTest()) {
-      TestConfiguration testConfiguration = TestConfiguration
-          .newBuilder()
-          .setPrettierJavaVersion(prettierJavaVersion)
-          .setInputGlobs(Arrays.asList(JAVA_INVALID_SYNTAX))
-          .setGoal(Goal.CHECK)
-          .build();
+  @TestFactory
+  public Stream<DynamicTest> itChecksInvalidJava() {
+    return getPrettierJavaVersionsToTest().stream().map(prettierJavaVersion ->
+        DynamicTest.dynamicTest("itChecksInvalidJava_prettier-java@" + prettierJavaVersion, () -> {
+          TestConfiguration testConfiguration = TestConfiguration
+              .newBuilder()
+              .setPrettierJavaVersion(prettierJavaVersion)
+              .setInputGlobs(Arrays.asList(JAVA_INVALID_SYNTAX))
+              .setGoal(Goal.CHECK)
+              .build();
 
-      MavenResult result = runMaven(testConfiguration);
+          MavenResult result = runMaven(testConfiguration);
 
-      assertThat(result.getSuccess()).isFalse();
-      assertThat(result.getOutput()).contains(BUILD_FAILURE);
-      assertThat(result.getOutput()).contains(invalidJavaSyntax());
-    }
+          assertThat(result.getSuccess()).isFalse();
+          assertThat(result.getOutput()).contains(BUILD_FAILURE);
+          assertThat(result.getOutput()).contains(invalidJavaSyntax());
+        })
+    );
   }
 
-  @Test
-  public void itChecksInvalidJs() throws Exception {
-    for (String prettierJavaVersion : getPrettierJavaVersionsToTest()) {
-      TestConfiguration testConfiguration = TestConfiguration
-          .newBuilder()
-          .setPrettierJavaVersion(prettierJavaVersion)
-          .setInputGlobs(Arrays.asList(JS_INVALID_SYNTAX))
-          .setGoal(Goal.CHECK)
-          .build();
+  @TestFactory
+  public Stream<DynamicTest> itChecksInvalidJs() {
+    return getPrettierJavaVersionsToTest().stream().map(prettierJavaVersion ->
+        DynamicTest.dynamicTest("itChecksInvalidJs_prettier-java@" + prettierJavaVersion, () -> {
+          TestConfiguration testConfiguration = TestConfiguration
+              .newBuilder()
+              .setPrettierJavaVersion(prettierJavaVersion)
+              .setInputGlobs(Arrays.asList(JS_INVALID_SYNTAX))
+              .setGoal(Goal.CHECK)
+              .build();
 
-      MavenResult result = runMaven(testConfiguration);
+          MavenResult result = runMaven(testConfiguration);
 
-      assertThat(result.getSuccess()).isFalse();
-      assertThat(result.getOutput()).contains(BUILD_FAILURE);
-      assertThat(result.getOutput()).contains(invalidJsSyntax());
-    }
+          assertThat(result.getSuccess()).isFalse();
+          assertThat(result.getOutput()).contains(BUILD_FAILURE);
+          assertThat(result.getOutput()).contains(invalidJsSyntax());
+        })
+    );
   }
 
-  @Test
-  public void itChecksInvalidJavaAndInvalidJs() throws Exception {
-    for (String prettierJavaVersion : getPrettierJavaVersionsToTest()) {
-      TestConfiguration testConfiguration = TestConfiguration
-          .newBuilder()
-          .setPrettierJavaVersion(prettierJavaVersion)
-          .setInputGlobs(Arrays.asList(JAVA_INVALID_SYNTAX, JS_INVALID_SYNTAX))
-          .setGoal(Goal.CHECK)
-          .build();
+  @TestFactory
+  public Stream<DynamicTest> itChecksInvalidJavaAndInvalidJs() {
+    return getPrettierJavaVersionsToTest().stream().map(prettierJavaVersion ->
+        DynamicTest.dynamicTest("itChecksInvalidJavaAndInvalidJs_prettier-java@" + prettierJavaVersion, () -> {
+          TestConfiguration testConfiguration = TestConfiguration
+              .newBuilder()
+              .setPrettierJavaVersion(prettierJavaVersion)
+              .setInputGlobs(Arrays.asList(JAVA_INVALID_SYNTAX, JS_INVALID_SYNTAX))
+              .setGoal(Goal.CHECK)
+              .build();
 
-      MavenResult result = runMaven(testConfiguration);
+          MavenResult result = runMaven(testConfiguration);
 
-      assertThat(result.getSuccess()).isFalse();
-      assertThat(result.getOutput()).contains(BUILD_FAILURE);
-      assertThat(result.getOutput()).contains(invalidJavaSyntax());
-      assertThat(result.getOutput()).contains(invalidJsSyntax());
-    }
+          assertThat(result.getSuccess()).isFalse();
+          assertThat(result.getOutput()).contains(BUILD_FAILURE);
+          assertThat(result.getOutput()).contains(invalidJavaSyntax());
+          assertThat(result.getOutput()).contains(invalidJsSyntax());
+        })
+    );
   }
 
-  @Test
-  public void itChecksUnknownExtensions() throws Exception {
-    for (String prettierJavaVersion : getPrettierJavaVersionsToTest()) {
-      TestConfiguration testConfiguration = TestConfiguration
-          .newBuilder()
-          .setPrettierJavaVersion(prettierJavaVersion)
-          .setInputGlobs(Arrays.asList(UNKNOWN_EXTENSION))
-          .setGoal(Goal.CHECK)
-          .build();
+  @TestFactory
+  public Stream<DynamicTest> itChecksUnknownExtensions() {
+    return getPrettierJavaVersionsToTest().stream().map(prettierJavaVersion ->
+        DynamicTest.dynamicTest("itChecksUnknownExtensions_prettier-java@" + prettierJavaVersion, () -> {
+          TestConfiguration testConfiguration = TestConfiguration
+              .newBuilder()
+              .setPrettierJavaVersion(prettierJavaVersion)
+              .setInputGlobs(Arrays.asList(UNKNOWN_EXTENSION))
+              .setGoal(Goal.CHECK)
+              .build();
 
-      MavenResult result = runMaven(testConfiguration);
+          MavenResult result = runMaven(testConfiguration);
 
-      assertThat(result.getSuccess()).isFalse();
-      assertThat(result.getOutput()).contains(BUILD_FAILURE);
-      assertThat(result.getOutput()).contains(unknownExtension());
-    }
+          assertThat(result.getSuccess()).isFalse();
+          assertThat(result.getOutput()).contains(BUILD_FAILURE);
+          assertThat(result.getOutput()).contains(unknownExtension());
+        })
+    );
   }
 
-  @Test
-  public void itChecksEmpty() throws Exception {
-    for (String prettierJavaVersion : getPrettierJavaVersionsToTest()) {
-      TestConfiguration testConfiguration = TestConfiguration
-          .newBuilder()
-          .setPrettierJavaVersion(prettierJavaVersion)
-          .setInputGlobs(Arrays.asList(EMPTY))
-          .setGoal(Goal.CHECK)
-          .build();
+  @TestFactory
+  public Stream<DynamicTest> itChecksEmpty() {
+    return getPrettierJavaVersionsToTest().stream().map(prettierJavaVersion ->
+        DynamicTest.dynamicTest("itChecksEmpty_prettier-java@" + prettierJavaVersion, () -> {
+          TestConfiguration testConfiguration = TestConfiguration
+              .newBuilder()
+              .setPrettierJavaVersion(prettierJavaVersion)
+              .setInputGlobs(Arrays.asList(EMPTY))
+              .setGoal(Goal.CHECK)
+              .build();
 
-      MavenResult result = runMaven(testConfiguration);
+          MavenResult result = runMaven(testConfiguration);
 
-      assertThat(result.getSuccess()).isTrue();
-      assertThat(result.getOutput()).contains(BUILD_SUCCESS);
-      assertThat(result.getOutput()).contains(noMatchingFiles(EMPTY));
-    }
+          assertThat(result.getSuccess()).isTrue();
+          assertThat(result.getOutput()).contains(BUILD_SUCCESS);
+          assertThat(result.getOutput()).contains(noMatchingFiles(EMPTY));
+        })
+    );
   }
 
-  @Test
-  public void itChecksGoodJavaAndBadJs() throws Exception {
-    for (String prettierJavaVersion : getPrettierJavaVersionsToTest()) {
-      TestConfiguration testConfiguration = TestConfiguration
-          .newBuilder()
-          .setPrettierJavaVersion(prettierJavaVersion)
-          .setInputGlobs(Arrays.asList(JAVA_GOOD_FORMATTING, JS_BAD_FORMATTING))
-          .setGoal(Goal.CHECK)
-          .build();
+  @TestFactory
+  public Stream<DynamicTest> itChecksGoodJavaAndBadJs() {
+    return getPrettierJavaVersionsToTest().stream().map(prettierJavaVersion ->
+        DynamicTest.dynamicTest("itChecksGoodJavaAndBadJs_prettier-java@" + prettierJavaVersion, () -> {
+          TestConfiguration testConfiguration = TestConfiguration
+              .newBuilder()
+              .setPrettierJavaVersion(prettierJavaVersion)
+              .setInputGlobs(Arrays.asList(JAVA_GOOD_FORMATTING, JS_BAD_FORMATTING))
+              .setGoal(Goal.CHECK)
+              .build();
 
-      MavenResult result = runMaven(testConfiguration);
+          MavenResult result = runMaven(testConfiguration);
 
-      assertThat(result.getSuccess()).isFalse();
-      assertThat(result.getOutput()).contains(BUILD_FAILURE);
-      assertThat(result.getOutput()).contains(incorrectlyFormattedFile(JS_BAD_FORMATTING));
-    }
+          assertThat(result.getSuccess()).isFalse();
+          assertThat(result.getOutput()).contains(BUILD_FAILURE);
+          assertThat(result.getOutput()).contains(incorrectlyFormattedFile(JS_BAD_FORMATTING));
+        })
+    );
   }
 
-  @Test
-  public void itChecksGoodJavaAndGoodJsAndEmpty() throws Exception {
-    for (String prettierJavaVersion : getPrettierJavaVersionsToTest()) {
-      TestConfiguration testConfiguration = TestConfiguration
-          .newBuilder()
-          .setPrettierJavaVersion(prettierJavaVersion)
-          .setInputGlobs(Arrays.asList(JAVA_GOOD_FORMATTING, JS_GOOD_FORMATTING, EMPTY))
-          .setGoal(Goal.CHECK)
-          .build();
+  @TestFactory
+  public Stream<DynamicTest> itChecksGoodJavaAndGoodJsAndEmpty() {
+    return getPrettierJavaVersionsToTest().stream().map(prettierJavaVersion ->
+        DynamicTest.dynamicTest("itChecksGoodJavaAndGoodJsAndEmpty_prettier-java@" + prettierJavaVersion, () -> {
+          TestConfiguration testConfiguration = TestConfiguration
+              .newBuilder()
+              .setPrettierJavaVersion(prettierJavaVersion)
+              .setInputGlobs(Arrays.asList(JAVA_GOOD_FORMATTING, JS_GOOD_FORMATTING, EMPTY))
+              .setGoal(Goal.CHECK)
+              .build();
 
-      MavenResult result = runMaven(testConfiguration);
+          MavenResult result = runMaven(testConfiguration);
 
-      assertThat(result.getSuccess()).isTrue();
-      assertThat(result.getOutput()).contains(BUILD_SUCCESS);
-      assertThat(result.getOutput()).doesNotContain(noMatchingFiles(JAVA_GOOD_FORMATTING));
-      assertThat(result.getOutput()).doesNotContain(noMatchingFiles(JS_GOOD_FORMATTING));
-      assertThat(result.getOutput()).contains(noMatchingFiles(EMPTY));
-    }
+          assertThat(result.getSuccess()).isTrue();
+          assertThat(result.getOutput()).contains(BUILD_SUCCESS);
+          assertThat(result.getOutput()).doesNotContain(noMatchingFiles(JAVA_GOOD_FORMATTING));
+          assertThat(result.getOutput()).doesNotContain(noMatchingFiles(JS_GOOD_FORMATTING));
+          assertThat(result.getOutput()).contains(noMatchingFiles(EMPTY));
+        })
+    );
   }
 
-  @Test
-  public void itChecksBadJavaAndBadJsAndEmpty() throws Exception {
-    for (String prettierJavaVersion : getPrettierJavaVersionsToTest()) {
-      TestConfiguration testConfiguration = TestConfiguration
-          .newBuilder()
-          .setPrettierJavaVersion(prettierJavaVersion)
-          .setInputGlobs(Arrays.asList(JAVA_BAD_FORMATTING, JS_BAD_FORMATTING, EMPTY))
-          .setGoal(Goal.CHECK)
-          .build();
+  @TestFactory
+  public Stream<DynamicTest> itChecksBadJavaAndBadJsAndEmpty() {
+    return getPrettierJavaVersionsToTest().stream().map(prettierJavaVersion ->
+        DynamicTest.dynamicTest("itChecksBadJavaAndBadJsAndEmpty_prettier-java@" + prettierJavaVersion, () -> {
+          TestConfiguration testConfiguration = TestConfiguration
+              .newBuilder()
+              .setPrettierJavaVersion(prettierJavaVersion)
+              .setInputGlobs(Arrays.asList(JAVA_BAD_FORMATTING, JS_BAD_FORMATTING, EMPTY))
+              .setGoal(Goal.CHECK)
+              .build();
 
-      MavenResult result = runMaven(testConfiguration);
+          MavenResult result = runMaven(testConfiguration);
 
-      assertThat(result.getSuccess()).isFalse();
-      assertThat(result.getOutput()).contains(BUILD_FAILURE);
-      assertThat(result.getOutput()).contains(incorrectlyFormattedFile(JAVA_BAD_FORMATTING));
-      assertThat(result.getOutput()).contains(incorrectlyFormattedFile(JS_BAD_FORMATTING));
-      assertThat(result.getOutput()).contains(noMatchingFiles(EMPTY));
-    }
+          assertThat(result.getSuccess()).isFalse();
+          assertThat(result.getOutput()).contains(BUILD_FAILURE);
+          assertThat(result.getOutput()).contains(incorrectlyFormattedFile(JAVA_BAD_FORMATTING));
+          assertThat(result.getOutput()).contains(incorrectlyFormattedFile(JS_BAD_FORMATTING));
+          assertThat(result.getOutput()).contains(noMatchingFiles(EMPTY));
+        })
+    );
   }
 }

--- a/prettier-maven-plugin-integration-tests/src/test/java/com/hubspot/maven/plugins/prettier/CheckMojoTest.java
+++ b/prettier-maven-plugin-integration-tests/src/test/java/com/hubspot/maven/plugins/prettier/CheckMojoTest.java
@@ -2,11 +2,9 @@ package com.hubspot.maven.plugins.prettier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Arrays;
-
-import org.junit.Test;
-
 import com.hubspot.maven.plugins.prettier.TestConfiguration.Goal;
+import java.util.Arrays;
+import org.junit.Test;
 
 public class CheckMojoTest extends AbstractPrettierMojoTest {
 
@@ -207,9 +205,7 @@ public class CheckMojoTest extends AbstractPrettierMojoTest {
 
       assertThat(result.getSuccess()).isTrue();
       assertThat(result.getOutput()).contains(BUILD_SUCCESS);
-      if (isNewishVersion(prettierJavaVersion)) {
-        assertThat(result.getOutput()).contains(noMatchingFiles(EMPTY));
-      }
+      assertThat(result.getOutput()).contains(noMatchingFiles(EMPTY));
     }
   }
 
@@ -247,9 +243,7 @@ public class CheckMojoTest extends AbstractPrettierMojoTest {
       assertThat(result.getOutput()).contains(BUILD_SUCCESS);
       assertThat(result.getOutput()).doesNotContain(noMatchingFiles(JAVA_GOOD_FORMATTING));
       assertThat(result.getOutput()).doesNotContain(noMatchingFiles(JS_GOOD_FORMATTING));
-      if (isNewishVersion(prettierJavaVersion)) {
-        assertThat(result.getOutput()).contains(noMatchingFiles(EMPTY));
-      }
+      assertThat(result.getOutput()).contains(noMatchingFiles(EMPTY));
     }
   }
 
@@ -269,9 +263,7 @@ public class CheckMojoTest extends AbstractPrettierMojoTest {
       assertThat(result.getOutput()).contains(BUILD_FAILURE);
       assertThat(result.getOutput()).contains(incorrectlyFormattedFile(JAVA_BAD_FORMATTING));
       assertThat(result.getOutput()).contains(incorrectlyFormattedFile(JS_BAD_FORMATTING));
-      if (isNewishVersion(prettierJavaVersion)) {
-        assertThat(result.getOutput()).contains(noMatchingFiles(EMPTY));
-      }
+      assertThat(result.getOutput()).contains(noMatchingFiles(EMPTY));
     }
   }
 }

--- a/prettier-maven-plugin-integration-tests/src/test/java/com/hubspot/maven/plugins/prettier/WriteMojoTest.java
+++ b/prettier-maven-plugin-integration-tests/src/test/java/com/hubspot/maven/plugins/prettier/WriteMojoTest.java
@@ -4,266 +4,296 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hubspot.maven.plugins.prettier.TestConfiguration.Goal;
 import java.util.Arrays;
-import org.junit.Test;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
 
 public class WriteMojoTest extends AbstractPrettierMojoTest {
 
-  @Test
-  public void itWritesGoodJava() throws Exception {
-    for (String prettierJavaVersion : getPrettierJavaVersionsToTest()) {
-      TestConfiguration testConfiguration = TestConfiguration
-          .newBuilder()
-          .setPrettierJavaVersion(prettierJavaVersion)
-          .setInputGlobs(Arrays.asList(JAVA_GOOD_FORMATTING))
-          .setGoal(Goal.WRITE)
-          .build();
+  @TestFactory
+  public Stream<DynamicTest> itWritesGoodJava() {
+    return getPrettierJavaVersionsToTest().stream().map(prettierJavaVersion ->
+        DynamicTest.dynamicTest("itWritesGoodJava_prettier-java@" + prettierJavaVersion, () -> {
+          TestConfiguration testConfiguration = TestConfiguration
+              .newBuilder()
+              .setPrettierJavaVersion(prettierJavaVersion)
+              .setInputGlobs(Arrays.asList(JAVA_GOOD_FORMATTING))
+              .setGoal(Goal.WRITE)
+              .build();
 
-      MavenResult result = runMaven(testConfiguration);
+          MavenResult result = runMaven(testConfiguration);
 
-      assertThat(result.getSuccess()).isTrue();
-      assertThat(result.getOutput()).contains(BUILD_SUCCESS);
-      assertThat(result.getOutput()).doesNotContain(noMatchingFiles(JAVA_GOOD_FORMATTING));
-    }
+          assertThat(result.getSuccess()).isTrue();
+          assertThat(result.getOutput()).contains(BUILD_SUCCESS);
+          assertThat(result.getOutput()).doesNotContain(noMatchingFiles(JAVA_GOOD_FORMATTING));
+        })
+    );
   }
 
-  @Test
-  public void itWritesGoodJs() throws Exception {
-    for (String prettierJavaVersion : getPrettierJavaVersionsToTest()) {
-      TestConfiguration testConfiguration = TestConfiguration
-          .newBuilder()
-          .setPrettierJavaVersion(prettierJavaVersion)
-          .setInputGlobs(Arrays.asList(JS_GOOD_FORMATTING))
-          .setGoal(Goal.WRITE)
-          .build();
+  @TestFactory
+  public Stream<DynamicTest> itWritesGoodJs() {
+    return getPrettierJavaVersionsToTest().stream().map(prettierJavaVersion ->
+        DynamicTest.dynamicTest("itWritesGoodJs_prettier-java@" + prettierJavaVersion, () -> {
+          TestConfiguration testConfiguration = TestConfiguration
+              .newBuilder()
+              .setPrettierJavaVersion(prettierJavaVersion)
+              .setInputGlobs(Arrays.asList(JS_GOOD_FORMATTING))
+              .setGoal(Goal.WRITE)
+              .build();
 
-      MavenResult result = runMaven(testConfiguration);
+          MavenResult result = runMaven(testConfiguration);
 
-      assertThat(result.getSuccess()).isTrue();
-      assertThat(result.getOutput()).contains(BUILD_SUCCESS);
-      assertThat(result.getOutput()).doesNotContain(noMatchingFiles(JS_GOOD_FORMATTING));
-    }
+          assertThat(result.getSuccess()).isTrue();
+          assertThat(result.getOutput()).contains(BUILD_SUCCESS);
+          assertThat(result.getOutput()).doesNotContain(noMatchingFiles(JS_GOOD_FORMATTING));
+        })
+    );
   }
 
-  @Test
-  public void itWritesGoodJavaAndGoodJs() throws Exception {
-    for (String prettierJavaVersion : getPrettierJavaVersionsToTest()) {
-      TestConfiguration testConfiguration = TestConfiguration
-          .newBuilder()
-          .setPrettierJavaVersion(prettierJavaVersion)
-          .setInputGlobs(Arrays.asList(JAVA_GOOD_FORMATTING, JS_GOOD_FORMATTING))
-          .setGoal(Goal.WRITE)
-          .build();
+  @TestFactory
+  public Stream<DynamicTest> itWritesGoodJavaAndGoodJs() {
+    return getPrettierJavaVersionsToTest().stream().map(prettierJavaVersion ->
+        DynamicTest.dynamicTest("itWritesGoodJavaAndGoodJs_prettier-java@" + prettierJavaVersion, () -> {
+          TestConfiguration testConfiguration = TestConfiguration
+              .newBuilder()
+              .setPrettierJavaVersion(prettierJavaVersion)
+              .setInputGlobs(Arrays.asList(JAVA_GOOD_FORMATTING, JS_GOOD_FORMATTING))
+              .setGoal(Goal.WRITE)
+              .build();
 
-      MavenResult result = runMaven(testConfiguration);
+          MavenResult result = runMaven(testConfiguration);
 
-      assertThat(result.getSuccess()).isTrue();
-      assertThat(result.getOutput()).contains(BUILD_SUCCESS);
-      assertThat(result.getOutput()).doesNotContain(noMatchingFiles(JAVA_GOOD_FORMATTING));
-      assertThat(result.getOutput()).doesNotContain(noMatchingFiles(JS_GOOD_FORMATTING));
-    }
+          assertThat(result.getSuccess()).isTrue();
+          assertThat(result.getOutput()).contains(BUILD_SUCCESS);
+          assertThat(result.getOutput()).doesNotContain(noMatchingFiles(JAVA_GOOD_FORMATTING));
+          assertThat(result.getOutput()).doesNotContain(noMatchingFiles(JS_GOOD_FORMATTING));
+        })
+    );
   }
 
-  @Test
-  public void itWritesBadJava() throws Exception {
-    for (String prettierJavaVersion : getPrettierJavaVersionsToTest()) {
-      TestConfiguration testConfiguration = TestConfiguration
-          .newBuilder()
-          .setPrettierJavaVersion(prettierJavaVersion)
-          .setInputGlobs(Arrays.asList(JAVA_BAD_FORMATTING))
-          .setGoal(Goal.WRITE)
-          .build();
+  @TestFactory
+  public Stream<DynamicTest> itWritesBadJava() {
+    return getPrettierJavaVersionsToTest().stream().map(prettierJavaVersion ->
+        DynamicTest.dynamicTest("itWritesBadJava_prettier-java@" + prettierJavaVersion, () -> {
+          TestConfiguration testConfiguration = TestConfiguration
+              .newBuilder()
+              .setPrettierJavaVersion(prettierJavaVersion)
+              .setInputGlobs(Arrays.asList(JAVA_BAD_FORMATTING))
+              .setGoal(Goal.WRITE)
+              .build();
 
-      MavenResult result = runMaven(testConfiguration);
+          MavenResult result = runMaven(testConfiguration);
 
-      assertThat(result.getSuccess()).isTrue();
-      assertThat(result.getOutput()).contains(BUILD_SUCCESS);
-      assertThat(result.getOutput()).contains(reformattedFile(JAVA_BAD_FORMATTING));
-    }
+          assertThat(result.getSuccess()).isTrue();
+          assertThat(result.getOutput()).contains(BUILD_SUCCESS);
+          assertThat(result.getOutput()).contains(reformattedFile(JAVA_BAD_FORMATTING));
+        })
+    );
   }
 
-  @Test
-  public void itWritesBadJs() throws Exception {
-    for (String prettierJavaVersion : getPrettierJavaVersionsToTest()) {
-      TestConfiguration testConfiguration = TestConfiguration
-          .newBuilder()
-          .setPrettierJavaVersion(prettierJavaVersion)
-          .setInputGlobs(Arrays.asList(JS_BAD_FORMATTING))
-          .setGoal(Goal.WRITE)
-          .build();
+  @TestFactory
+  public Stream<DynamicTest> itWritesBadJs() {
+    return getPrettierJavaVersionsToTest().stream().map(prettierJavaVersion ->
+        DynamicTest.dynamicTest("itWritesBadJs_prettier-java@" + prettierJavaVersion, () -> {
+          TestConfiguration testConfiguration = TestConfiguration
+              .newBuilder()
+              .setPrettierJavaVersion(prettierJavaVersion)
+              .setInputGlobs(Arrays.asList(JS_BAD_FORMATTING))
+              .setGoal(Goal.WRITE)
+              .build();
 
-      MavenResult result = runMaven(testConfiguration);
+          MavenResult result = runMaven(testConfiguration);
 
-      assertThat(result.getSuccess()).isTrue();
-      assertThat(result.getOutput()).contains(BUILD_SUCCESS);
-      assertThat(result.getOutput()).contains(reformattedFile(JS_BAD_FORMATTING));
-    }
+          assertThat(result.getSuccess()).isTrue();
+          assertThat(result.getOutput()).contains(BUILD_SUCCESS);
+          assertThat(result.getOutput()).contains(reformattedFile(JS_BAD_FORMATTING));
+        })
+    );
   }
 
-  @Test
-  public void itWritesBadJavaAndBadJs() throws Exception {
-    for (String prettierJavaVersion : getPrettierJavaVersionsToTest()) {
-      TestConfiguration testConfiguration = TestConfiguration
-          .newBuilder()
-          .setPrettierJavaVersion(prettierJavaVersion)
-          .setInputGlobs(Arrays.asList(JAVA_BAD_FORMATTING, JS_BAD_FORMATTING))
-          .setGoal(Goal.WRITE)
-          .build();
+  @TestFactory
+  public Stream<DynamicTest> itWritesBadJavaAndBadJs() {
+    return getPrettierJavaVersionsToTest().stream().map(prettierJavaVersion ->
+        DynamicTest.dynamicTest("itWritesBadJavaAndBadJs_prettier-java@" + prettierJavaVersion, () -> {
+          TestConfiguration testConfiguration = TestConfiguration
+              .newBuilder()
+              .setPrettierJavaVersion(prettierJavaVersion)
+              .setInputGlobs(Arrays.asList(JAVA_BAD_FORMATTING, JS_BAD_FORMATTING))
+              .setGoal(Goal.WRITE)
+              .build();
 
-      MavenResult result = runMaven(testConfiguration);
+          MavenResult result = runMaven(testConfiguration);
 
-      assertThat(result.getSuccess()).isTrue();
-      assertThat(result.getOutput()).contains(BUILD_SUCCESS);
-      assertThat(result.getOutput()).contains(reformattedFile(JAVA_BAD_FORMATTING));
-      assertThat(result.getOutput()).contains(reformattedFile(JS_BAD_FORMATTING));
-    }
+          assertThat(result.getSuccess()).isTrue();
+          assertThat(result.getOutput()).contains(BUILD_SUCCESS);
+          assertThat(result.getOutput()).contains(reformattedFile(JAVA_BAD_FORMATTING));
+          assertThat(result.getOutput()).contains(reformattedFile(JS_BAD_FORMATTING));
+        })
+    );
   }
 
-  @Test
-  public void itWritesInvalidJava() throws Exception {
-    for (String prettierJavaVersion : getPrettierJavaVersionsToTest()) {
-      TestConfiguration testConfiguration = TestConfiguration
-          .newBuilder()
-          .setPrettierJavaVersion(prettierJavaVersion)
-          .setInputGlobs(Arrays.asList(JAVA_INVALID_SYNTAX))
-          .setGoal(Goal.WRITE)
-          .build();
+  @TestFactory
+  public Stream<DynamicTest> itWritesInvalidJava() {
+    return getPrettierJavaVersionsToTest().stream().map(prettierJavaVersion ->
+        DynamicTest.dynamicTest("itWritesInvalidJava_prettier-java@" + prettierJavaVersion, () -> {
+          TestConfiguration testConfiguration = TestConfiguration
+              .newBuilder()
+              .setPrettierJavaVersion(prettierJavaVersion)
+              .setInputGlobs(Arrays.asList(JAVA_INVALID_SYNTAX))
+              .setGoal(Goal.WRITE)
+              .build();
 
-      MavenResult result = runMaven(testConfiguration);
+          MavenResult result = runMaven(testConfiguration);
 
-      assertThat(result.getSuccess()).isFalse();
-      assertThat(result.getOutput()).contains(BUILD_FAILURE);
-      assertThat(result.getOutput()).contains(invalidJavaSyntax());
-    }
+          assertThat(result.getSuccess()).isFalse();
+          assertThat(result.getOutput()).contains(BUILD_FAILURE);
+          assertThat(result.getOutput()).contains(invalidJavaSyntax());
+        })
+    );
   }
 
-  @Test
-  public void itWritesInvalidJs() throws Exception {
-    for (String prettierJavaVersion : getPrettierJavaVersionsToTest()) {
-      TestConfiguration testConfiguration = TestConfiguration
-          .newBuilder()
-          .setPrettierJavaVersion(prettierJavaVersion)
-          .setInputGlobs(Arrays.asList(JS_INVALID_SYNTAX))
-          .setGoal(Goal.WRITE)
-          .build();
+  @TestFactory
+  public Stream<DynamicTest> itWritesInvalidJs() {
+    return getPrettierJavaVersionsToTest().stream().map(prettierJavaVersion ->
+        DynamicTest.dynamicTest("itWritesInvalidJs_prettier-java@" + prettierJavaVersion, () -> {
+          TestConfiguration testConfiguration = TestConfiguration
+              .newBuilder()
+              .setPrettierJavaVersion(prettierJavaVersion)
+              .setInputGlobs(Arrays.asList(JS_INVALID_SYNTAX))
+              .setGoal(Goal.WRITE)
+              .build();
 
-      MavenResult result = runMaven(testConfiguration);
+          MavenResult result = runMaven(testConfiguration);
 
-      assertThat(result.getSuccess()).isFalse();
-      assertThat(result.getOutput()).contains(BUILD_FAILURE);
-      assertThat(result.getOutput()).contains(invalidJsSyntax());
-    }
+          assertThat(result.getSuccess()).isFalse();
+          assertThat(result.getOutput()).contains(BUILD_FAILURE);
+          assertThat(result.getOutput()).contains(invalidJsSyntax());
+        })
+    );
   }
 
-  @Test
-  public void itWritesInvalidJavaAndInvalidJs() throws Exception {
-    for (String prettierJavaVersion : getPrettierJavaVersionsToTest()) {
-      TestConfiguration testConfiguration = TestConfiguration
-          .newBuilder()
-          .setPrettierJavaVersion(prettierJavaVersion)
-          .setInputGlobs(Arrays.asList(JAVA_INVALID_SYNTAX, JS_INVALID_SYNTAX))
-          .setGoal(Goal.WRITE)
-          .build();
+  @TestFactory
+  public Stream<DynamicTest> itWritesInvalidJavaAndInvalidJs() {
+    return getPrettierJavaVersionsToTest().stream().map(prettierJavaVersion ->
+        DynamicTest.dynamicTest("itWritesInvalidJavaAndInvalidJs_prettier-java@" + prettierJavaVersion, () -> {
+          TestConfiguration testConfiguration = TestConfiguration
+              .newBuilder()
+              .setPrettierJavaVersion(prettierJavaVersion)
+              .setInputGlobs(Arrays.asList(JAVA_INVALID_SYNTAX, JS_INVALID_SYNTAX))
+              .setGoal(Goal.WRITE)
+              .build();
 
-      MavenResult result = runMaven(testConfiguration);
+          MavenResult result = runMaven(testConfiguration);
 
-      assertThat(result.getSuccess()).isFalse();
-      assertThat(result.getOutput()).contains(BUILD_FAILURE);
-      assertThat(result.getOutput()).contains(invalidJavaSyntax());
-      assertThat(result.getOutput()).contains(invalidJsSyntax());
-    }
+          assertThat(result.getSuccess()).isFalse();
+          assertThat(result.getOutput()).contains(BUILD_FAILURE);
+          assertThat(result.getOutput()).contains(invalidJavaSyntax());
+          assertThat(result.getOutput()).contains(invalidJsSyntax());
+        })
+    );
   }
 
-  @Test
-  public void itWritesUnknownExtensions() throws Exception {
-    for (String prettierJavaVersion : getPrettierJavaVersionsToTest()) {
-      TestConfiguration testConfiguration = TestConfiguration
-          .newBuilder()
-          .setPrettierJavaVersion(prettierJavaVersion)
-          .setInputGlobs(Arrays.asList(UNKNOWN_EXTENSION))
-          .setGoal(Goal.WRITE)
-          .build();
+  @TestFactory
+  public Stream<DynamicTest> itWritesUnknownExtensions() {
+    return getPrettierJavaVersionsToTest().stream().map(prettierJavaVersion ->
+        DynamicTest.dynamicTest("itWritesUnknownExtensions_prettier-java@" + prettierJavaVersion, () -> {
+          TestConfiguration testConfiguration = TestConfiguration
+              .newBuilder()
+              .setPrettierJavaVersion(prettierJavaVersion)
+              .setInputGlobs(Arrays.asList(UNKNOWN_EXTENSION))
+              .setGoal(Goal.WRITE)
+              .build();
 
-      MavenResult result = runMaven(testConfiguration);
+          MavenResult result = runMaven(testConfiguration);
 
-      assertThat(result.getSuccess()).isFalse();
-      assertThat(result.getOutput()).contains(BUILD_FAILURE);
-      assertThat(result.getOutput()).contains(unknownExtension());
-    }
+          assertThat(result.getSuccess()).isFalse();
+          assertThat(result.getOutput()).contains(BUILD_FAILURE);
+          assertThat(result.getOutput()).contains(unknownExtension());
+        })
+    );
   }
 
-  @Test
-  public void itWritesEmpty() throws Exception {
-    for (String prettierJavaVersion : getPrettierJavaVersionsToTest()) {
-      TestConfiguration testConfiguration = TestConfiguration
-          .newBuilder()
-          .setPrettierJavaVersion(prettierJavaVersion)
-          .setInputGlobs(Arrays.asList(EMPTY))
-          .setGoal(Goal.WRITE)
-          .build();
+  @TestFactory
+  public Stream<DynamicTest> itWritesEmpty() {
+    return getPrettierJavaVersionsToTest().stream().map(prettierJavaVersion ->
+        DynamicTest.dynamicTest("itWritesEmpty_prettier-java@" + prettierJavaVersion, () -> {
+          TestConfiguration testConfiguration = TestConfiguration
+              .newBuilder()
+              .setPrettierJavaVersion(prettierJavaVersion)
+              .setInputGlobs(Arrays.asList(EMPTY))
+              .setGoal(Goal.WRITE)
+              .build();
 
-      MavenResult result = runMaven(testConfiguration);
+          MavenResult result = runMaven(testConfiguration);
 
-      assertThat(result.getSuccess()).isTrue();
-      assertThat(result.getOutput()).contains(BUILD_SUCCESS);
-      assertThat(result.getOutput()).contains(noMatchingFiles(EMPTY));
-    }
+          assertThat(result.getSuccess()).isTrue();
+          assertThat(result.getOutput()).contains(BUILD_SUCCESS);
+          assertThat(result.getOutput()).contains(noMatchingFiles(EMPTY));
+        })
+    );
   }
 
-  @Test
-  public void itWritesGoodJavaAndBadJs() throws Exception {
-    for (String prettierJavaVersion : getPrettierJavaVersionsToTest()) {
-      TestConfiguration testConfiguration = TestConfiguration
-          .newBuilder()
-          .setPrettierJavaVersion(prettierJavaVersion)
-          .setInputGlobs(Arrays.asList(JAVA_GOOD_FORMATTING, JS_BAD_FORMATTING))
-          .setGoal(Goal.WRITE)
-          .build();
+  @TestFactory
+  public Stream<DynamicTest> itWritesGoodJavaAndBadJs() {
+    return getPrettierJavaVersionsToTest().stream().map(prettierJavaVersion ->
+        DynamicTest.dynamicTest("itWritesGoodJavaAndBadJs_prettier-java@" + prettierJavaVersion, () -> {
+          TestConfiguration testConfiguration = TestConfiguration
+              .newBuilder()
+              .setPrettierJavaVersion(prettierJavaVersion)
+              .setInputGlobs(Arrays.asList(JAVA_GOOD_FORMATTING, JS_BAD_FORMATTING))
+              .setGoal(Goal.WRITE)
+              .build();
 
-      MavenResult result = runMaven(testConfiguration);
+          MavenResult result = runMaven(testConfiguration);
 
-      assertThat(result.getSuccess()).isTrue();
-      assertThat(result.getOutput()).contains(BUILD_SUCCESS);
-      assertThat(result.getOutput()).contains(reformattedFile(JS_BAD_FORMATTING));
-    }
+          assertThat(result.getSuccess()).isTrue();
+          assertThat(result.getOutput()).contains(BUILD_SUCCESS);
+          assertThat(result.getOutput()).contains(reformattedFile(JS_BAD_FORMATTING));
+        })
+    );
   }
 
-  @Test
-  public void itWritesGoodJavaAndGoodJsAndEmpty() throws Exception {
-    for (String prettierJavaVersion : getPrettierJavaVersionsToTest()) {
-      TestConfiguration testConfiguration = TestConfiguration
-          .newBuilder()
-          .setPrettierJavaVersion(prettierJavaVersion)
-          .setInputGlobs(Arrays.asList(JAVA_GOOD_FORMATTING, JS_GOOD_FORMATTING, EMPTY))
-          .setGoal(Goal.WRITE)
-          .build();
+  @TestFactory
+  public Stream<DynamicTest> itWritesGoodJavaAndGoodJsAndEmpty() {
+    return getPrettierJavaVersionsToTest().stream().map(prettierJavaVersion ->
+        DynamicTest.dynamicTest("itWritesGoodJavaAndGoodJsAndEmpty_prettier-java@" + prettierJavaVersion, () -> {
+          TestConfiguration testConfiguration = TestConfiguration
+              .newBuilder()
+              .setPrettierJavaVersion(prettierJavaVersion)
+              .setInputGlobs(Arrays.asList(JAVA_GOOD_FORMATTING, JS_GOOD_FORMATTING, EMPTY))
+              .setGoal(Goal.WRITE)
+              .build();
 
-      MavenResult result = runMaven(testConfiguration);
+          MavenResult result = runMaven(testConfiguration);
 
-      assertThat(result.getSuccess()).isTrue();
-      assertThat(result.getOutput()).contains(BUILD_SUCCESS);
-      assertThat(result.getOutput()).doesNotContain(noMatchingFiles(JAVA_GOOD_FORMATTING));
-      assertThat(result.getOutput()).doesNotContain(noMatchingFiles(JS_GOOD_FORMATTING));
-      assertThat(result.getOutput()).contains(noMatchingFiles(EMPTY));
-    }
+          assertThat(result.getSuccess()).isTrue();
+          assertThat(result.getOutput()).contains(BUILD_SUCCESS);
+          assertThat(result.getOutput()).doesNotContain(noMatchingFiles(JAVA_GOOD_FORMATTING));
+          assertThat(result.getOutput()).doesNotContain(noMatchingFiles(JS_GOOD_FORMATTING));
+          assertThat(result.getOutput()).contains(noMatchingFiles(EMPTY));
+        })
+    );
   }
 
-  @Test
-  public void itWritesBadJavaAndBadJsAndEmpty() throws Exception {
-    for (String prettierJavaVersion : getPrettierJavaVersionsToTest()) {
-      TestConfiguration testConfiguration = TestConfiguration
-          .newBuilder()
-          .setPrettierJavaVersion(prettierJavaVersion)
-          .setInputGlobs(Arrays.asList(JAVA_BAD_FORMATTING, JS_BAD_FORMATTING, EMPTY))
-          .setGoal(Goal.WRITE)
-          .build();
+  @TestFactory
+  public Stream<DynamicTest> itWritesBadJavaAndBadJsAndEmpty() {
+    return getPrettierJavaVersionsToTest().stream().map(prettierJavaVersion ->
+        DynamicTest.dynamicTest("itWritesBadJavaAndBadJsAndEmpty_prettier-java@" + prettierJavaVersion, () -> {
+          TestConfiguration testConfiguration = TestConfiguration
+              .newBuilder()
+              .setPrettierJavaVersion(prettierJavaVersion)
+              .setInputGlobs(Arrays.asList(JAVA_BAD_FORMATTING, JS_BAD_FORMATTING, EMPTY))
+              .setGoal(Goal.WRITE)
+              .build();
 
-      MavenResult result = runMaven(testConfiguration);
+          MavenResult result = runMaven(testConfiguration);
 
-      assertThat(result.getSuccess()).isTrue();
-      assertThat(result.getOutput()).contains(BUILD_SUCCESS);
-      assertThat(result.getOutput()).contains(reformattedFile(JAVA_BAD_FORMATTING));
-      assertThat(result.getOutput()).contains(reformattedFile(JS_BAD_FORMATTING));
-      assertThat(result.getOutput()).contains(noMatchingFiles(EMPTY));
-    }
+          assertThat(result.getSuccess()).isTrue();
+          assertThat(result.getOutput()).contains(BUILD_SUCCESS);
+          assertThat(result.getOutput()).contains(reformattedFile(JAVA_BAD_FORMATTING));
+          assertThat(result.getOutput()).contains(reformattedFile(JS_BAD_FORMATTING));
+          assertThat(result.getOutput()).contains(noMatchingFiles(EMPTY));
+        })
+    );
   }
 }

--- a/prettier-maven-plugin-integration-tests/src/test/java/com/hubspot/maven/plugins/prettier/WriteMojoTest.java
+++ b/prettier-maven-plugin-integration-tests/src/test/java/com/hubspot/maven/plugins/prettier/WriteMojoTest.java
@@ -2,11 +2,9 @@ package com.hubspot.maven.plugins.prettier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Arrays;
-
-import org.junit.Test;
-
 import com.hubspot.maven.plugins.prettier.TestConfiguration.Goal;
+import java.util.Arrays;
+import org.junit.Test;
 
 public class WriteMojoTest extends AbstractPrettierMojoTest {
 
@@ -207,9 +205,7 @@ public class WriteMojoTest extends AbstractPrettierMojoTest {
 
       assertThat(result.getSuccess()).isTrue();
       assertThat(result.getOutput()).contains(BUILD_SUCCESS);
-      if (isNewishVersion(prettierJavaVersion)) {
-        assertThat(result.getOutput()).contains(noMatchingFiles(EMPTY));
-      }
+      assertThat(result.getOutput()).contains(noMatchingFiles(EMPTY));
     }
   }
 
@@ -247,9 +243,7 @@ public class WriteMojoTest extends AbstractPrettierMojoTest {
       assertThat(result.getOutput()).contains(BUILD_SUCCESS);
       assertThat(result.getOutput()).doesNotContain(noMatchingFiles(JAVA_GOOD_FORMATTING));
       assertThat(result.getOutput()).doesNotContain(noMatchingFiles(JS_GOOD_FORMATTING));
-      if (isNewishVersion(prettierJavaVersion)) {
-        assertThat(result.getOutput()).contains(noMatchingFiles(EMPTY));
-      }
+      assertThat(result.getOutput()).contains(noMatchingFiles(EMPTY));
     }
   }
 
@@ -269,9 +263,7 @@ public class WriteMojoTest extends AbstractPrettierMojoTest {
       assertThat(result.getOutput()).contains(BUILD_SUCCESS);
       assertThat(result.getOutput()).contains(reformattedFile(JAVA_BAD_FORMATTING));
       assertThat(result.getOutput()).contains(reformattedFile(JS_BAD_FORMATTING));
-      if (isNewishVersion(prettierJavaVersion)) {
-        assertThat(result.getOutput()).contains(noMatchingFiles(EMPTY));
-      }
+      assertThat(result.getOutput()).contains(noMatchingFiles(EMPTY));
     }
   }
 }

--- a/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/AbstractPrettierMojo.java
+++ b/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/AbstractPrettierMojo.java
@@ -1,6 +1,7 @@
 package com.hubspot.maven.plugins.prettier;
 
 import com.hubspot.maven.plugins.prettier.internal.NodeInstall;
+import com.hubspot.maven.plugins.prettier.internal.PrettierPaths;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -102,14 +103,8 @@ public abstract class AbstractPrettierMojo extends PrettierArgs {
 
     Path prettierJavaDirectory = downloadPrettierJava(nodeInstall);
 
-    Path prettierBin = prettierJavaDirectory
-        .resolve("node_modules")
-        .resolve("prettier")
-        .resolve("bin-prettier.js");
-
-    Path prettierJavaPlugin = prettierJavaDirectory
-        .resolve("node_modules")
-        .resolve("prettier-plugin-java");
+    Path prettierBin = prettierJavaDirectory.resolve(PrettierPaths.prettierBinPath(prettierJavaVersion));
+    Path prettierJavaPlugin = prettierJavaDirectory.resolve(PrettierPaths.prettierJavaPluginPath(prettierJavaVersion));
 
     List<String> command = new ArrayList<>();
     command.add(nodeInstall.getNodePath());

--- a/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/PrettierArgs.java
+++ b/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/PrettierArgs.java
@@ -1,5 +1,11 @@
 package com.hubspot.maven.plugins.prettier;
 
+import com.google.common.io.Resources;
+import com.hubspot.maven.plugins.prettier.internal.NodeDownloader;
+import com.hubspot.maven.plugins.prettier.internal.NodeInstall;
+import com.hubspot.maven.plugins.prettier.internal.OperatingSystemFamily;
+import com.hubspot.maven.plugins.prettier.internal.PrettierDownloader;
+import com.hubspot.maven.plugins.prettier.internal.PrettierPatcher;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -10,9 +16,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-
 import javax.annotation.Nullable;
-
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -20,13 +24,6 @@ import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
-
-import com.google.common.io.Resources;
-import com.hubspot.maven.plugins.prettier.internal.NodeDownloader;
-import com.hubspot.maven.plugins.prettier.internal.NodeInstall;
-import com.hubspot.maven.plugins.prettier.internal.OperatingSystemFamily;
-import com.hubspot.maven.plugins.prettier.internal.PrettierDownloader;
-import com.hubspot.maven.plugins.prettier.internal.PrettierPatcher;
 
 public abstract class PrettierArgs extends AbstractMojo {
   /**
@@ -54,7 +51,7 @@ public abstract class PrettierArgs extends AbstractMojo {
   private String npmPath;
 
   @Parameter(defaultValue = "0.7.0", property = "prettier.prettierJavaVersion")
-  private String prettierJavaVersion;
+  protected String prettierJavaVersion;
 
   // TODO remove
   @Parameter(defaultValue = "false")
@@ -139,7 +136,7 @@ public abstract class PrettierArgs extends AbstractMojo {
       if (disableGenericsLinebreaks) {
         if (prettierJavaVersion.startsWith("2")) {
           URL patch = Resources.getResource("no-linebreak-generics.patch");
-          return new PrettierPatcher(prettierJava, getLog()).patch(patch);
+          return new PrettierPatcher(prettierJava, getLog()).patch(patch, prettierJavaVersion);
         } else if ("1.5.0".compareTo(prettierJavaVersion) > 0) {
           // versions before 1.5.0 don't linebreak generics
           return prettierJava;

--- a/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/PrintArgsMojo.java
+++ b/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/PrintArgsMojo.java
@@ -1,6 +1,7 @@
 package com.hubspot.maven.plugins.prettier;
 
 import com.hubspot.maven.plugins.prettier.internal.NodeInstall;
+import com.hubspot.maven.plugins.prettier.internal.PrettierPaths;
 import java.nio.file.Path;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -14,15 +15,8 @@ public class PrintArgsMojo extends PrettierArgs {
     NodeInstall nodeInstall = resolveNodeInstall();
 
     Path prettierJavaDirectory = downloadPrettierJava(nodeInstall);
-
-    Path prettierBin = prettierJavaDirectory
-      .resolve("node_modules")
-      .resolve("prettier")
-      .resolve("bin-prettier.js");
-
-    Path prettierJavaPlugin = prettierJavaDirectory
-      .resolve("node_modules")
-      .resolve("prettier-plugin-java");
+    Path prettierBin = prettierJavaDirectory.resolve(PrettierPaths.prettierBinPath(prettierJavaVersion));
+    Path prettierJavaPlugin = prettierJavaDirectory.resolve(PrettierPaths.prettierJavaPluginPath(prettierJavaVersion));
 
     /*
     Use System.out rather than getLog() because we don't want any leading characters

--- a/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/internal/PrettierDownloader.java
+++ b/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/internal/PrettierDownloader.java
@@ -9,7 +9,6 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 
 public class PrettierDownloader {
-  private static final String PRETTIER_BIN_PATH = "node_modules/prettier/bin-prettier.js";
   private final Path installDirectory;
   private final NodeInstall nodeInstall;
   private final Log log;
@@ -22,7 +21,7 @@ public class PrettierDownloader {
 
   public Path downloadPrettierJava(String prettierJavaVersion) throws MojoExecutionException {
     Path prettierDirectory = installDirectory.resolve("prettier-java-" + prettierJavaVersion);
-    Path prettierBin = prettierDirectory.resolve(PRETTIER_BIN_PATH);
+    Path prettierBin = prettierDirectory.resolve(PrettierPaths.prettierBinPath(prettierJavaVersion));
 
     if (Files.exists(prettierDirectory) && Files.exists(prettierBin)) {
       log.debug("Reusing cached prettier-java at: " + prettierDirectory);
@@ -64,7 +63,7 @@ public class PrettierDownloader {
 
     try {
       int exitCode = process.waitFor();
-      boolean prettierBinExists = Files.exists(tmpDir.resolve(PRETTIER_BIN_PATH));
+      boolean prettierBinExists = Files.exists(tmpDir.resolve(PrettierPaths.prettierBinPath(prettierJavaVersion)));
       if (exitCode != 0) {
         throw new MojoExecutionException("Error downloading prettier-java, exit code: " + exitCode);
       }

--- a/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/internal/PrettierPatcher.java
+++ b/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/internal/PrettierPatcher.java
@@ -21,9 +21,9 @@ public class PrettierPatcher {
     this.log = log;
   }
 
-  public Path patch(URL patch) throws MojoExecutionException {
+  public Path patch(URL patch, String prettierJavaVersion) throws MojoExecutionException {
     Path patchDirectory = originalDirectory.resolveSibling(originalDirectory.getFileName() + "-patched");
-    Path prettierBin = patchDirectory.resolve("node_modules/prettier/bin-prettier.js");
+    Path prettierBin = patchDirectory.resolve(PrettierPaths.prettierBinPath(prettierJavaVersion));
 
     if (Files.exists(patchDirectory) && Files.exists(prettierBin)) {
       log.debug("Reusing patched prettier-java at: " + patchDirectory);

--- a/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/internal/PrettierPaths.java
+++ b/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/internal/PrettierPaths.java
@@ -1,0 +1,27 @@
+package com.hubspot.maven.plugins.prettier.internal;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class PrettierPaths {
+  private static final Path OLD_PRETTIER_BIN_PATH = Paths.get("node_modules/prettier/bin-prettier.js");
+  private static final Path NEW_PRETTIER_BIN_PATH = Paths.get("node_modules/prettier/bin/prettier.cjs");
+  private static final Path OLD_PRETTIER_JAVA_PLUGIN_PATH = Paths.get("node_modules/prettier-plugin-java");
+  private static final Path NEW_PRETTIER_JAVA_PLUGIN_PATH = Paths.get("node_modules/prettier-plugin-java/dist/index.js");
+
+  public static Path prettierBinPath(String prettierVersion) {
+    if ("2.2.0".compareTo(prettierVersion) > 0) {
+      return OLD_PRETTIER_BIN_PATH;
+    } else {
+      return NEW_PRETTIER_BIN_PATH;
+    }
+  }
+
+  public static Path prettierJavaPluginPath(String prettierVersion) {
+    if ("2.2.0".compareTo(prettierVersion) > 0) {
+      return OLD_PRETTIER_JAVA_PLUGIN_PATH;
+    } else {
+      return NEW_PRETTIER_JAVA_PLUGIN_PATH;
+    }
+  }
+}


### PR DESCRIPTION
Related to #91 

prettier-java v2.2.0 uses prettier v3, which requires some changes in file paths / how we invoke things.
