### PR TITLE
extract patch command to parameter for overriding

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ If you want to customize the behavior of prettier, you can use a normal prettier
 | ignoreEditorConfig  | prettier.ignoreEditorConfig  | `false`                          | If set to true, pretter will be invoked with `--no-editorconfig`. More information [here](https://prettier.io/docs/en/cli.html#--no-editorconfig)                                                                                                                 |
 | inputGlobs          | prettier.inputGlobs          | `src/{main,test}/java/**/*.java` | Controls the input paths passed to prettier, useful for formatting additional directories or file types. More information [here](https://prettier.io/docs/en/cli.html#file-patterns)                                                                              |
 | disableGenericsLinebreaks | prettier.disableGenericsLinebreaks | `false` | Prevents prettier from adding linebreaks to generic type declarations (see https://github.com/HubSpot/prettier-maven-plugin/pull/78 for more background) |
+| patchCommand        | prettier.patchCommand        | `patch`                          | Patch command to use for `disableGenericsLinebreaks` (i.e. `"/usr/bin/patch"`)  |
 
 ### Note
 

--- a/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/PrettierArgs.java
+++ b/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/PrettierArgs.java
@@ -78,6 +78,9 @@ public abstract class PrettierArgs extends AbstractMojo {
   @Parameter(defaultValue = "false", property = "prettier.disableGenericsLinebreaks")
   protected boolean disableGenericsLinebreaks;
 
+  @Parameter(defaultValue = "patch", property = "prettier.patchCommand")
+  protected String patchCommand;
+
   @Nullable
   @Parameter(property = "prettier.endOfLine")
   protected String endOfLine;

--- a/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/internal/PrettierPatcher.java
+++ b/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/internal/PrettierPatcher.java
@@ -16,9 +16,12 @@ public class PrettierPatcher {
   private final Path originalDirectory;
   private final Log log;
 
-  public PrettierPatcher(Path originalDirectory, Log log) {
+  private final String patchCommand;
+
+  public PrettierPatcher(Path originalDirectory, Log log, String patchCommand) {
     this.originalDirectory = originalDirectory;
     this.log = log;
+    this.patchCommand = patchCommand;
   }
 
   public Path patch(URL patch, String prettierJavaVersion) throws MojoExecutionException {
@@ -46,7 +49,7 @@ public class PrettierPatcher {
   }
 
   private void applyPatch(URL patch, Path directory) throws MojoExecutionException, IOException {
-    List<String> command = Arrays.asList("patch", "-p1", "-f");
+    List<String> command = Arrays.asList(patchCommand, "-p1", "-f");
     log.debug("Running patch command: " + command);
 
     Process process = new ProcessBuilder(command.toArray(new String[0]))


### PR DESCRIPTION
this will allow me to set `<patchCommand>/usr/bin/patch</patchCommand>` to fix this build issue I'm encountering:

```
[ERROR] Failed to execute goal com.hubspot.maven.plugins:prettier-maven-plugin:0.21-SNAPSHOT:write (default-cli) on project foo: Error patching prettier-java: Cannot run program "patch" (in directory "/build/sandbox/app/.m2/repository/com/hubspot/maven/plugins/prettier-maven-plugin/0.21-SNAPSHOT/prettier-java-396189222533385624"): error=2, No such file or directory -> [Help 1]
```

@jhaber 