### PR TITLE
Revert "extract patch command to parameter for overriding"

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ If you want to customize the behavior of prettier, you can use a normal prettier
 | ignoreEditorConfig  | prettier.ignoreEditorConfig  | `false`                          | If set to true, pretter will be invoked with `--no-editorconfig`. More information [here](https://prettier.io/docs/en/cli.html#--no-editorconfig)                                                                                                                 |
 | inputGlobs          | prettier.inputGlobs          | `src/{main,test}/java/**/*.java` | Controls the input paths passed to prettier, useful for formatting additional directories or file types. More information [here](https://prettier.io/docs/en/cli.html#file-patterns)                                                                              |
 | disableGenericsLinebreaks | prettier.disableGenericsLinebreaks | `false` | Prevents prettier from adding linebreaks to generic type declarations (see https://github.com/HubSpot/prettier-maven-plugin/pull/78 for more background) |
-| patchCommand        | prettier.patchCommand        | `/usr/bin/patch`                          | Patch command to use for `disableGenericsLinebreaks`  |
 
 ### Note
 

--- a/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/PrettierArgs.java
+++ b/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/PrettierArgs.java
@@ -78,9 +78,6 @@ public abstract class PrettierArgs extends AbstractMojo {
   @Parameter(defaultValue = "false", property = "prettier.disableGenericsLinebreaks")
   protected boolean disableGenericsLinebreaks;
 
-  @Parameter(defaultValue = "/usr/bin/patch", property = "prettier.patchCommand")
-  protected String patchCommand;
-
   @Nullable
   @Parameter(property = "prettier.endOfLine")
   protected String endOfLine;
@@ -139,7 +136,7 @@ public abstract class PrettierArgs extends AbstractMojo {
       if (disableGenericsLinebreaks) {
         if (prettierJavaVersion.startsWith("2")) {
           URL patch = Resources.getResource("no-linebreak-generics.patch");
-          return new PrettierPatcher(prettierJava, getLog(), patchCommand).patch(patch, prettierJavaVersion);
+          return new PrettierPatcher(prettierJava, getLog()).patch(patch, prettierJavaVersion);
         } else if ("1.5.0".compareTo(prettierJavaVersion) > 0) {
           // versions before 1.5.0 don't linebreak generics
           return prettierJava;

--- a/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/internal/PrettierPatcher.java
+++ b/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/internal/PrettierPatcher.java
@@ -16,12 +16,9 @@ public class PrettierPatcher {
   private final Path originalDirectory;
   private final Log log;
 
-  private final String patchCommand;
-
-  public PrettierPatcher(Path originalDirectory, Log log, String patchCommand) {
+  public PrettierPatcher(Path originalDirectory, Log log) {
     this.originalDirectory = originalDirectory;
     this.log = log;
-    this.patchCommand = patchCommand;
   }
 
   public Path patch(URL patch, String prettierJavaVersion) throws MojoExecutionException {
@@ -49,7 +46,7 @@ public class PrettierPatcher {
   }
 
   private void applyPatch(URL patch, Path directory) throws MojoExecutionException, IOException {
-    List<String> command = Arrays.asList(patchCommand, "-p1", "-f");
+    List<String> command = Arrays.asList("patch", "-p1", "-f");
     log.debug("Running patch command: " + command);
 
     Process process = new ProcessBuilder(command.toArray(new String[0]))


### PR DESCRIPTION
Reverts HubSpot/prettier-maven-plugin#96

i'd misunderstood my root issue, which was that my task image didn't have the `patch` command at all.
