### PR TITLE
Remove Guava dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,11 +47,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>31.0.1-jre</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-core</artifactId>
         <version>3.6.2</version>

--- a/prettier-maven-plugin-integration-tests/pom.xml
+++ b/prettier-maven-plugin-integration-tests/pom.xml
@@ -16,11 +16,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/prettier-maven-plugin-integration-tests/src/test/java/com/hubspot/maven/plugins/prettier/TestConfiguration.java
+++ b/prettier-maven-plugin-integration-tests/src/test/java/com/hubspot/maven/plugins/prettier/TestConfiguration.java
@@ -1,8 +1,7 @@
 package com.hubspot.maven.plugins.prettier;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Preconditions;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class TestConfiguration {
@@ -40,7 +39,7 @@ public class TestConfiguration {
     return template
         .replace(
             "${nodeVersion}",
-            MoreObjects.firstNonNull(System.getenv("PRETTIER_NODE_VERSION"), "19.3.0")
+            Objects.requireNonNullElse(System.getenv("PRETTIER_NODE_VERSION"), "19.3.0")
         )
         .replace("${pluginVersion}", System.getenv("PLUGIN_VERSION"))
         .replace("${prettierJavaVersion}", prettierJavaVersion)
@@ -62,17 +61,17 @@ public class TestConfiguration {
     private Builder() {}
 
   public Builder setPrettierJavaVersion(String prettierJavaVersion) {
-    this.prettierJavaVersion = Preconditions.checkNotNull(prettierJavaVersion);
+    this.prettierJavaVersion = Objects.requireNonNull(prettierJavaVersion);
     return this;
   }
 
   public Builder setInputGlobs(List<String> inputGlobs) {
-    this.inputGlobs = Preconditions.checkNotNull(inputGlobs);
+    this.inputGlobs = Objects.requireNonNull(inputGlobs);
     return this;
   }
 
   public Builder setGoal(Goal goal) {
-    this.goal = Preconditions.checkNotNull(goal);
+    this.goal = Objects.requireNonNull(goal);
     return this;
   }
 

--- a/prettier-maven-plugin/pom.xml
+++ b/prettier-maven-plugin/pom.xml
@@ -38,10 +38,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
       <version>4.9.3</version>

--- a/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/PrettierArgs.java
+++ b/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/PrettierArgs.java
@@ -1,6 +1,5 @@
 package com.hubspot.maven.plugins.prettier;
 
-import com.google.common.io.Resources;
 import com.hubspot.maven.plugins.prettier.internal.NodeDownloader;
 import com.hubspot.maven.plugins.prettier.internal.NodeInstall;
 import com.hubspot.maven.plugins.prettier.internal.OperatingSystemFamily;
@@ -135,7 +134,7 @@ public abstract class PrettierArgs extends AbstractMojo {
 
       if (disableGenericsLinebreaks) {
         if (prettierJavaVersion.startsWith("2")) {
-          URL patch = Resources.getResource("no-linebreak-generics.patch");
+          URL patch = getClass().getResource("/no-linebreak-generics.patch");
           return new PrettierPatcher(prettierJava, getLog()).patch(patch, prettierJavaVersion);
         } else if ("1.5.0".compareTo(prettierJavaVersion) > 0) {
           // versions before 1.5.0 don't linebreak generics


### PR DESCRIPTION
Replace the few Guava uses with standard Java equivalents, and remove Guava as a dependency (to reduce the plugin's footprint).