### PR TITLE
fix log parsing for files with "error" in the path

### DIFF
--- a/prettier-maven-plugin-integration-tests/src/test/java/com/hubspot/maven/plugins/prettier/AbstractPrettierMojoTest.java
+++ b/prettier-maven-plugin-integration-tests/src/test/java/com/hubspot/maven/plugins/prettier/AbstractPrettierMojoTest.java
@@ -25,6 +25,7 @@ public abstract class AbstractPrettierMojoTest {
 
   protected static final String JAVA_GOOD_FORMATTING = "java-good-formatting/*.java";
   protected static final String JAVA_BAD_FORMATTING = "java-bad-formatting/*.java";
+  protected static final String JAVA_BAD_FORMATTING_ERROR_PATH = "java-bad-formatting-error-path/*.java";
   protected static final String JAVA_INVALID_SYNTAX = "java-invalid-syntax/*.java";
   protected static final String JS_GOOD_FORMATTING = "js-good-formatting/*.js";
   protected static final String JS_BAD_FORMATTING = "js-bad-formatting/*.js";

--- a/prettier-maven-plugin-integration-tests/src/test/java/com/hubspot/maven/plugins/prettier/CheckMojoTest.java
+++ b/prettier-maven-plugin-integration-tests/src/test/java/com/hubspot/maven/plugins/prettier/CheckMojoTest.java
@@ -72,6 +72,25 @@ public class CheckMojoTest extends AbstractPrettierMojoTest {
   }
 
   @TestFactory
+  public Stream<DynamicTest> itChecksBadJavaWithErrorInPath() {
+    return getPrettierJavaVersionsToTest().stream().map(prettierJavaVersion ->
+        DynamicTest.dynamicTest("itChecksBadJavaWithErrorInPath_prettier-java@" + prettierJavaVersion, () -> {
+          TestConfiguration testConfiguration = TestConfiguration
+              .newBuilder()
+              .setPrettierJavaVersion(prettierJavaVersion)
+              .setInputGlobs(Arrays.asList(JAVA_BAD_FORMATTING_ERROR_PATH))
+              .setGoal(Goal.CHECK)
+              .build();
+
+          MavenResult result = runMaven(testConfiguration);
+
+          assertThat(result.getSuccess()).isFalse();
+          assertThat(result.getOutput()).contains(BUILD_FAILURE);
+          assertThat(result.getOutput()).contains(incorrectlyFormattedFile(JAVA_BAD_FORMATTING_ERROR_PATH));
+        }));
+  }
+
+  @TestFactory
   public Stream<DynamicTest> itChecksBadJava() {
     return getPrettierJavaVersionsToTest().stream().map(prettierJavaVersion ->
         DynamicTest.dynamicTest("itChecksBadJava_prettier-java@" + prettierJavaVersion, () -> {

--- a/prettier-maven-plugin-integration-tests/src/test/resources/test-files/java-bad-formatting-error-path/Test.java
+++ b/prettier-maven-plugin-integration-tests/src/test/resources/test-files/java-bad-formatting-error-path/Test.java
@@ -1,0 +1,3 @@
+  public class Test {
+
+}

--- a/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/AbstractPrettierMojo.java
+++ b/prettier-maven-plugin/src/main/java/com/hubspot/maven/plugins/prettier/AbstractPrettierMojo.java
@@ -9,11 +9,15 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Parameter;
 
 public abstract class AbstractPrettierMojo extends PrettierArgs {
+
+  private static final Pattern ANSI_COLOR_CODE = Pattern.compile("\u001B\\[[;\\d]*m");
 
   @Parameter(defaultValue = "false")
   private boolean skip;
@@ -71,7 +75,7 @@ public abstract class AbstractPrettierMojo extends PrettierArgs {
         while ((line = stderr.readLine()) != null) {
           if (line.contains("No matching files.") || line.contains("No files matching")) {
             getLog().info(trimLogLevel(line));
-          } else if (line.contains("error")) {
+          } else if (ANSI_COLOR_CODE.matcher(line).replaceAll("").startsWith("[error]")) {
             getLog().error(trimLogLevel(line));
             hasError = true;
           } else {


### PR DESCRIPTION
Currently, the stderr parsing logic treats any line containing `"error"` as an error, but this includes non-error log lines for files with error in the path (i.e. `/foo/bar/error/MyErrorHandler.java`)

As a consequence, you'll see this for a non-errored bad-formatting state:
```
[INFO] --- prettier:0.21-SNAPSHOT:check (check) @ team-error-prone-checks ---
[INFO] Using customized nodePath: /opt/build-deps/node-18.7.0/bin/node
[INFO] Using customized npmPath: /opt/build-deps/node-18.7.0/lib/node_modules/npm/bin/npm-cli.js
[ERROR] src/main/java/com/hubspot/error/prone/checks/ValidateAnnotation.java
[ERROR] src/main/java/com/hubspot/error/prone/checks/ValidateMethodAnnotation.java
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
...
[ERROR] Failed to execute goal com.hubspot.maven.plugins:prettier-maven-plugin:0.21-SNAPSHOT:check (check) on project team-error-prone-checks: Error trying to run prettier-java: 1 -> [Help 1]
```

@jhaber @stevie400 @Xcelled 
